### PR TITLE
Feature#19: Modal 컴포넌트 구현

### DIFF
--- a/chromatic.config.json
+++ b/chromatic.config.json
@@ -1,0 +1,5 @@
+{
+  "onlyChanged": true,
+  "projectId": "Project:6772e94da2d4f5be7f071f50",
+  "zip": true
+}

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@radix-ui/react-avatar": "^1.1.1",
     "@radix-ui/react-checkbox": "^1.1.2",
-    "@radix-ui/react-dialog": "^1.1.2",
+    "@radix-ui/react-dialog": "^1.1.4",
     "@radix-ui/react-label": "^2.1.1",
     "@radix-ui/react-popover": "^1.1.2",
     "@radix-ui/react-progress": "^1.1.0",

--- a/src/@types/index.d.ts
+++ b/src/@types/index.d.ts
@@ -21,3 +21,7 @@ declare type CSSRelativeUnit =
     | "%";
 
 declare type SizeProp = `${number}${CSSAbsoluteUnit | CSSRelativeUnit}`;
+
+declare type Children = {
+    children: React.ReactNode;
+};

--- a/src/shared/components/Modal/Modal.stories.tsx
+++ b/src/shared/components/Modal/Modal.stories.tsx
@@ -1,0 +1,40 @@
+import { Modal } from "./Modal";
+import { ModalContextProvider } from "@/shared/components/Modal/ModalContextProvider";
+import { useModal } from "@/shared/components/Modal/useModal";
+import { Button } from "@/shared/ui";
+import type { Meta, StoryObj } from "@storybook/react";
+
+const meta: Meta<typeof Modal.Content> = {
+    title: "Shared/Modal",
+    component: Modal.Content,
+};
+
+export default meta;
+type Story = StoryObj<typeof Modal>;
+
+const Content = () => {
+    const { closeModal } = useModal();
+    return (
+        <div className="flex gap-1">
+            <Button variant="default" onClick={() => closeModal()}>
+                Confirm
+            </Button>
+            <Button variant="outline" onClick={() => closeModal()}>
+                Cancel
+            </Button>
+        </div>
+    );
+};
+
+export const Default: Story = {
+    args: {},
+    render: () => {
+        return (
+            <ModalContextProvider>
+                <Modal.Root>
+                    <Content />
+                </Modal.Root>
+            </ModalContextProvider>
+        );
+    },
+};

--- a/src/shared/components/Modal/Modal.tsx
+++ b/src/shared/components/Modal/Modal.tsx
@@ -1,0 +1,81 @@
+import { useEffect } from "react";
+import { createPortal } from "react-dom";
+
+import { useModal } from "@/shared/components/Modal/useModal";
+import { useInitialStyle } from "@/shared/hooks";
+
+export interface ModalProps {
+    children?: React.ReactNode;
+}
+
+const Root = ({ children }: ModalProps) => {
+    const { isOpen } = useModal();
+    if (!isOpen) return null;
+
+    return createPortal(
+        <Modal.Container>
+            <Modal.Overlay />
+            <Modal.Content>{children}</Modal.Content>
+        </Modal.Container>,
+        document.body,
+    );
+};
+
+const Container = ({ children }: { children?: React.ReactNode }) => {
+    return (
+        <div className="fixed inset-0 w-screen h-screen z-[100] grid place-items-center">
+            {children}
+        </div>
+    );
+};
+
+const Overlay = () => {
+    const { closeModal } = useModal();
+    return (
+        <div
+            className="fixed top-0 left-0 w-screen h-screen bg-black/70 z-[100]"
+            onClick={() => closeModal()}
+        />
+    );
+};
+
+const Content = ({ children }: { children?: React.ReactNode }) => {
+    const { isOpen } = useModal();
+
+    const { ref } = useInitialStyle<HTMLDivElement>({
+        opacity: "0",
+        transform: "scale(0.7)",
+    });
+
+    useEffect(() => {
+        const element = ref.current;
+        if (!element) return;
+
+        if (isOpen) {
+            element.style.opacity = "1";
+            element.style.transform = "scale(1)";
+        } else {
+            element.style.opacity = "0";
+            element.style.transform = "scale(0.7)";
+        }
+    }, [isOpen, ref]);
+
+    return (
+        <div
+            ref={ref}
+            className="bg-white z-[200] fixed p-4 rounded-md"
+            style={{
+                transition: "opacity 0.3s, transform 0.3s",
+            }}
+        >
+            {children}
+        </div>
+    );
+};
+
+export const Modal = {
+    Root,
+    Container,
+    Overlay,
+    Content,
+};

--- a/src/shared/components/Modal/ModalContext.tsx
+++ b/src/shared/components/Modal/ModalContext.tsx
@@ -1,0 +1,13 @@
+import { createContext } from "react";
+
+export interface ModalContextProps {
+    isOpen: boolean;
+
+    openModal: () => void;
+    closeModal: () => void;
+
+    onConfirm: () => void;
+    onCancel: () => void;
+}
+
+export const ModalContext = createContext<ModalContextProps | null>(null);

--- a/src/shared/components/Modal/ModalContextProvider.tsx
+++ b/src/shared/components/Modal/ModalContextProvider.tsx
@@ -1,0 +1,29 @@
+import { useReducer } from "react";
+
+import { ModalContext } from "./ModalContext";
+import { MODAL_DISPATCH_ACTION_TYPES, modalReducer, modalState } from "@/shared/components";
+
+export interface ModalContextProps {
+    children: React.ReactNode;
+}
+
+export const ModalContextProvider = ({ children }: ModalContextProps) => {
+    const [state, dispatch] = useReducer<typeof modalReducer>(modalReducer, modalState);
+
+    const openModal = () => dispatch({ type: MODAL_DISPATCH_ACTION_TYPES.OPEN_MODAL });
+    const closeModal = () => dispatch({ type: MODAL_DISPATCH_ACTION_TYPES.CLOSE_MODAL });
+
+    return (
+        <ModalContext.Provider
+            value={{
+                isOpen: state.isOpen,
+                openModal,
+                closeModal,
+                onConfirm: () => dispatch({ type: MODAL_DISPATCH_ACTION_TYPES.CLOSE_MODAL }),
+                onCancel: () => dispatch({ type: MODAL_DISPATCH_ACTION_TYPES.CLOSE_MODAL }),
+            }}
+        >
+            {children}
+        </ModalContext.Provider>
+    );
+};

--- a/src/shared/components/Modal/index.ts
+++ b/src/shared/components/Modal/index.ts
@@ -1,0 +1,3 @@
+export * from "./Modal";
+export * from "./ModalContext";
+export * from "./useModal";

--- a/src/shared/components/Modal/useModal.tsx
+++ b/src/shared/components/Modal/useModal.tsx
@@ -1,0 +1,41 @@
+import { useContext } from "react";
+
+import { ModalContext } from "./ModalContext";
+
+export enum MODAL_DISPATCH_ACTION_TYPES {
+    OPEN_MODAL = "OPEN_MODAL",
+    CLOSE_MODAL = "CLOSE_MODAL",
+}
+
+export type ModalState = {
+    isOpen: boolean;
+};
+
+export const modalState: ModalState = {
+    isOpen: true,
+};
+
+export type ModalDispatchAction =
+    | {
+          type: MODAL_DISPATCH_ACTION_TYPES.OPEN_MODAL;
+      }
+    | {
+          type: MODAL_DISPATCH_ACTION_TYPES.CLOSE_MODAL;
+      };
+
+export const modalReducer = (state: ModalState, action: ModalDispatchAction): ModalState => {
+    switch (action.type) {
+        case MODAL_DISPATCH_ACTION_TYPES.OPEN_MODAL:
+            return { ...state, isOpen: true };
+        case MODAL_DISPATCH_ACTION_TYPES.CLOSE_MODAL:
+            return { ...state, isOpen: false };
+        default:
+            return state;
+    }
+};
+
+export const useModal = () => {
+    const context = useContext(ModalContext);
+    if (!context) throw new Error("useModal 는 ModalContextProvider 내부에서 사용되어야 합니다");
+    return context;
+};

--- a/src/shared/components/__tests__/ModalContext.test.tsx
+++ b/src/shared/components/__tests__/ModalContext.test.tsx
@@ -1,0 +1,39 @@
+import {
+    MODAL_DISPATCH_ACTION_TYPES,
+    modalReducer,
+    modalState,
+    useModal,
+} from "@/shared/components/Modal";
+import { renderHook } from "@testing-library/react";
+
+describe("ModalContext", () => {
+    describe("useModal()", () => {
+        test("useModal 이 ModalContextProvider 내부에서 사용되지 않으면 에러를 반환한다", () => {
+            try {
+                renderHook(() => useModal());
+            } catch (e: any) {
+                expect(e.message).toBe(
+                    "useModal 는 ModalContextProvider 내부에서 사용되어야 합니다",
+                );
+            }
+        });
+    });
+
+    describe("modalReducer()", () => {
+        test("OPEN_MODAL : modalState 의 isOpen 상태를 true 로 변경한다", () => {
+            const updatedState = modalReducer(modalState, {
+                type: MODAL_DISPATCH_ACTION_TYPES.OPEN_MODAL,
+            });
+
+            expect(updatedState.isOpen).toBe(true);
+        });
+
+        test("CLOSE_MODAL : modalState 의 isOpen 상태를 false 로 변경한다", () => {
+            const updatedState = modalReducer(modalState, {
+                type: MODAL_DISPATCH_ACTION_TYPES.CLOSE_MODAL,
+            });
+
+            expect(updatedState.isOpen).toBe(false);
+        });
+    });
+});

--- a/src/shared/components/index.ts
+++ b/src/shared/components/index.ts
@@ -1,2 +1,3 @@
 export * from "./NavPrevious";
 export * from "./Selector";
+export * from "./Modal";

--- a/src/shared/hooks/__test__/useInitialStyle.test.tsx
+++ b/src/shared/hooks/__test__/useInitialStyle.test.tsx
@@ -1,0 +1,34 @@
+import { useInitialStyle } from "../useInitialStyle";
+import { render, screen } from "@testing-library/react";
+
+describe("useInitialStyle()", () => {
+    test("ref 에 해당하는 DOM 요소에 initialStyles 를 적용한다", () => {
+        const Component = () => {
+            const { ref } = useInitialStyle<HTMLDivElement>({
+                opacity: "0",
+                transform: "scale(0.8)",
+            });
+            return <div data-testid="test" ref={ref}></div>;
+        };
+
+        render(<Component />);
+
+        const el = screen.getByTestId("test");
+
+        expect(el.style.opacity).toBe("0");
+        expect(el.style.transform).toBe("scale(0.8)");
+    });
+
+    test("Object.entries 를 통해 style 을 순회하며 key,value 를 반환한다", () => {
+        const style: React.CSSProperties = {
+            opacity: "0",
+            transform: "scale(0.8)",
+        };
+
+        const styleKeys = Object.keys(style);
+
+        expect(styleKeys).toEqual(["opacity", "transform"]);
+        expect(style["opacity"]).toBe("0");
+        expect(style["transform"]).toBe("scale(0.8)");
+    });
+});

--- a/src/shared/hooks/index.ts
+++ b/src/shared/hooks/index.ts
@@ -1,1 +1,2 @@
 export * from "./useRemoveSearchParams";
+export * from "./useInitialStyle";

--- a/src/shared/hooks/useInitialStyle.tsx
+++ b/src/shared/hooks/useInitialStyle.tsx
@@ -1,0 +1,17 @@
+import { useLayoutEffect, useRef } from "react";
+
+export const useInitialStyle = <Element extends HTMLElement = HTMLElement>(
+    initialStyles: React.CSSProperties,
+) => {
+    const ref = useRef<Element>(null);
+
+    useLayoutEffect(() => {
+        const element = ref.current;
+        if (!element) return;
+
+        for (const [key, value] of Object.entries(initialStyles))
+            element.style.setProperty(key, value);
+    }, [initialStyles]);
+
+    return { ref };
+};

--- a/src/shared/ui/dialog.tsx
+++ b/src/shared/ui/dialog.tsx
@@ -1,0 +1,120 @@
+import * as React from "react"
+import * as DialogPrimitive from "@radix-ui/react-dialog"
+import { X } from "lucide-react"
+
+import { cn } from "@/shared/lib/utils"
+
+const Dialog = DialogPrimitive.Root
+
+const DialogTrigger = DialogPrimitive.Trigger
+
+const DialogPortal = DialogPrimitive.Portal
+
+const DialogClose = DialogPrimitive.Close
+
+const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className
+    )}
+    {...props}
+  />
+))
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
+
+const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </DialogPortal>
+))
+DialogContent.displayName = DialogPrimitive.Content.displayName
+
+const DialogHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col space-y-1.5 text-center sm:text-left",
+      className
+    )}
+    {...props}
+  />
+)
+DialogHeader.displayName = "DialogHeader"
+
+const DialogFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      className
+    )}
+    {...props}
+  />
+)
+DialogFooter.displayName = "DialogFooter"
+
+const DialogTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn(
+      "text-lg font-semibold leading-none tracking-tight",
+      className
+    )}
+    {...props}
+  />
+))
+DialogTitle.displayName = DialogPrimitive.Title.displayName
+
+const DialogDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+DialogDescription.displayName = DialogPrimitive.Description.displayName
+
+export {
+  Dialog,
+  DialogPortal,
+  DialogOverlay,
+  DialogClose,
+  DialogTrigger,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+}

--- a/src/shared/ui/dialog.tsx
+++ b/src/shared/ui/dialog.tsx
@@ -1,120 +1,106 @@
-import * as React from "react"
-import * as DialogPrimitive from "@radix-ui/react-dialog"
-import { X } from "lucide-react"
+import * as React from "react";
 
-import { cn } from "@/shared/lib/utils"
+import { X } from "lucide-react";
 
-const Dialog = DialogPrimitive.Root
+import { cn } from "@/shared/lib/utils";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
 
-const DialogTrigger = DialogPrimitive.Trigger
+const Dialog = DialogPrimitive.Root;
 
-const DialogPortal = DialogPrimitive.Portal
+const DialogTrigger = DialogPrimitive.Trigger;
 
-const DialogClose = DialogPrimitive.Close
+const DialogPortal = DialogPrimitive.Portal;
+
+const DialogClose = DialogPrimitive.Close;
 
 const DialogOverlay = React.forwardRef<
-  React.ElementRef<typeof DialogPrimitive.Overlay>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+    React.ElementRef<typeof DialogPrimitive.Overlay>,
+    React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
 >(({ className, ...props }, ref) => (
-  <DialogPrimitive.Overlay
-    ref={ref}
-    className={cn(
-      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
-      className
-    )}
-    {...props}
-  />
-))
-DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
+    <DialogPrimitive.Overlay
+        ref={ref}
+        className={cn(
+            "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+            className,
+        )}
+        {...props}
+    />
+));
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
 
 const DialogContent = React.forwardRef<
-  React.ElementRef<typeof DialogPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+    React.ElementRef<typeof DialogPrimitive.Content>,
+    React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
 >(({ className, children, ...props }, ref) => (
-  <DialogPortal>
-    <DialogOverlay />
-    <DialogPrimitive.Content
-      ref={ref}
-      className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
-        className
-      )}
-      {...props}
-    >
-      {children}
-      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
-        <X className="h-4 w-4" />
-        <span className="sr-only">Close</span>
-      </DialogPrimitive.Close>
-    </DialogPrimitive.Content>
-  </DialogPortal>
-))
-DialogContent.displayName = DialogPrimitive.Content.displayName
+    <DialogPortal>
+        <DialogOverlay />
+        <DialogPrimitive.Content
+            ref={ref}
+            className={cn(
+                "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+                className,
+            )}
+            {...props}
+        >
+            {children}
+            <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+                <X className="w-4 h-4" />
+                <span className="sr-only">Close</span>
+            </DialogPrimitive.Close>
+        </DialogPrimitive.Content>
+    </DialogPortal>
+));
+DialogContent.displayName = DialogPrimitive.Content.displayName;
 
-const DialogHeader = ({
-  className,
-  ...props
-}: React.HTMLAttributes<HTMLDivElement>) => (
-  <div
-    className={cn(
-      "flex flex-col space-y-1.5 text-center sm:text-left",
-      className
-    )}
-    {...props}
-  />
-)
-DialogHeader.displayName = "DialogHeader"
+const DialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+    <div
+        className={cn("flex flex-col space-y-1.5 text-center sm:text-left", className)}
+        {...props}
+    />
+);
+DialogHeader.displayName = "DialogHeader";
 
-const DialogFooter = ({
-  className,
-  ...props
-}: React.HTMLAttributes<HTMLDivElement>) => (
-  <div
-    className={cn(
-      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
-      className
-    )}
-    {...props}
-  />
-)
-DialogFooter.displayName = "DialogFooter"
+const DialogFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+    <div
+        className={cn("flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2", className)}
+        {...props}
+    />
+);
+DialogFooter.displayName = "DialogFooter";
 
 const DialogTitle = React.forwardRef<
-  React.ElementRef<typeof DialogPrimitive.Title>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+    React.ElementRef<typeof DialogPrimitive.Title>,
+    React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
 >(({ className, ...props }, ref) => (
-  <DialogPrimitive.Title
-    ref={ref}
-    className={cn(
-      "text-lg font-semibold leading-none tracking-tight",
-      className
-    )}
-    {...props}
-  />
-))
-DialogTitle.displayName = DialogPrimitive.Title.displayName
+    <DialogPrimitive.Title
+        ref={ref}
+        className={cn("text-lg font-semibold leading-none tracking-tight", className)}
+        {...props}
+    />
+));
+DialogTitle.displayName = DialogPrimitive.Title.displayName;
 
 const DialogDescription = React.forwardRef<
-  React.ElementRef<typeof DialogPrimitive.Description>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+    React.ElementRef<typeof DialogPrimitive.Description>,
+    React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
 >(({ className, ...props }, ref) => (
-  <DialogPrimitive.Description
-    ref={ref}
-    className={cn("text-sm text-muted-foreground", className)}
-    {...props}
-  />
-))
-DialogDescription.displayName = DialogPrimitive.Description.displayName
+    <DialogPrimitive.Description
+        ref={ref}
+        className={cn("text-sm text-muted-foreground", className)}
+        {...props}
+    />
+));
+DialogDescription.displayName = DialogPrimitive.Description.displayName;
 
 export {
-  Dialog,
-  DialogPortal,
-  DialogOverlay,
-  DialogClose,
-  DialogTrigger,
-  DialogContent,
-  DialogHeader,
-  DialogFooter,
-  DialogTitle,
-  DialogDescription,
-}
+    Dialog,
+    DialogPortal,
+    DialogOverlay,
+    DialogClose,
+    DialogTrigger,
+    DialogContent,
+    DialogHeader,
+    DialogFooter,
+    DialogTitle,
+    DialogDescription,
+};

--- a/src/shared/ui/index.ts
+++ b/src/shared/ui/index.ts
@@ -12,3 +12,4 @@ export * from "./slider";
 export * from "./toggle-group";
 export * from "./toggle";
 export * from "./label";
+export * from "./dialog";

--- a/yarn.lock
+++ b/yarn.lock
@@ -1092,6 +1092,11 @@
   resolved "https://registry.yarnpkg.com/@radix-ui/primitive/-/primitive-1.1.0.tgz#42ef83b3b56dccad5d703ae8c42919a68798bbe2"
   integrity sha512-4Z8dn6Upk0qk4P74xBhZ6Hd/w0mPEzOOLxy4xiPXOXqjF7jZS0VAKk7/x/H6FyY2zCkYJqePf1G5KmkmNJ4RBA==
 
+"@radix-ui/primitive@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/primitive/-/primitive-1.1.1.tgz#fc169732d755c7fbad33ba8d0cd7fd10c90dc8e3"
+  integrity sha512-SJ31y+Q/zAyShtXJc8x83i9TYdbAfHZ++tUZnvjJJqFjzsdUnKsxPL6IEtBlxKkU7yzer//GQtZSV4GbldL3YA==
+
 "@radix-ui/react-arrow@1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-arrow/-/react-arrow-1.1.0.tgz#744f388182d360b86285217e43b6c63633f39e7a"
@@ -1153,7 +1158,7 @@
   resolved "https://registry.yarnpkg.com/@radix-ui/react-context/-/react-context-1.1.1.tgz#82074aa83a472353bb22e86f11bcbd1c61c4c71a"
   integrity sha512-UASk9zi+crv9WteK/NU4PLvOoL3OuE6BWVKNF6hPRBtYBDXQ2u5iu3O59zUlJiTVvkyuycnqrztsHVJwcK9K+Q==
 
-"@radix-ui/react-dialog@^1.1.1", "@radix-ui/react-dialog@^1.1.2":
+"@radix-ui/react-dialog@^1.1.1":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-dialog/-/react-dialog-1.1.2.tgz#d9345575211d6f2d13e209e84aec9a8584b54d6c"
   integrity sha512-Yj4dZtqa2o+kG61fzB0H2qUvmwBA2oyQroGLyNtBj1beo1khoQ3q1a2AO8rrQYjd8256CO9+N8L9tvsS+bnIyA==
@@ -1173,6 +1178,26 @@
     aria-hidden "^1.1.1"
     react-remove-scroll "2.6.0"
 
+"@radix-ui/react-dialog@^1.1.4":
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-dialog/-/react-dialog-1.1.4.tgz#d68e977acfcc0d044b9dab47b6dd2c179d2b3191"
+  integrity sha512-Ur7EV1IwQGCyaAuyDRiOLA5JIUZxELJljF+MbM/2NC0BYwfuRrbpS30BiQBJrVruscgUkieKkqXYDOoByaxIoA==
+  dependencies:
+    "@radix-ui/primitive" "1.1.1"
+    "@radix-ui/react-compose-refs" "1.1.1"
+    "@radix-ui/react-context" "1.1.1"
+    "@radix-ui/react-dismissable-layer" "1.1.3"
+    "@radix-ui/react-focus-guards" "1.1.1"
+    "@radix-ui/react-focus-scope" "1.1.1"
+    "@radix-ui/react-id" "1.1.0"
+    "@radix-ui/react-portal" "1.1.3"
+    "@radix-ui/react-presence" "1.1.2"
+    "@radix-ui/react-primitive" "2.0.1"
+    "@radix-ui/react-slot" "1.1.1"
+    "@radix-ui/react-use-controllable-state" "1.1.0"
+    aria-hidden "^1.1.1"
+    react-remove-scroll "^2.6.1"
+
 "@radix-ui/react-direction@1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-direction/-/react-direction-1.1.0.tgz#a7d39855f4d077adc2a1922f9c353c5977a09cdc"
@@ -1189,6 +1214,17 @@
     "@radix-ui/react-use-callback-ref" "1.1.0"
     "@radix-ui/react-use-escape-keydown" "1.1.0"
 
+"@radix-ui/react-dismissable-layer@1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.3.tgz#4ee0f0f82d53bf5bd9db21665799bb0d1bad5ed8"
+  integrity sha512-onrWn/72lQoEucDmJnr8uczSNTujT0vJnA/X5+3AkChVPowr8n1yvIKIabhWyMQeMvvmdpsvcyDqx3X1LEXCPg==
+  dependencies:
+    "@radix-ui/primitive" "1.1.1"
+    "@radix-ui/react-compose-refs" "1.1.1"
+    "@radix-ui/react-primitive" "2.0.1"
+    "@radix-ui/react-use-callback-ref" "1.1.0"
+    "@radix-ui/react-use-escape-keydown" "1.1.0"
+
 "@radix-ui/react-focus-guards@1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.1.tgz#8635edd346304f8b42cae86b05912b61aef27afe"
@@ -1201,6 +1237,15 @@
   dependencies:
     "@radix-ui/react-compose-refs" "1.1.0"
     "@radix-ui/react-primitive" "2.0.0"
+    "@radix-ui/react-use-callback-ref" "1.1.0"
+
+"@radix-ui/react-focus-scope@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.1.tgz#5c602115d1db1c4fcfa0fae4c3b09bb8919853cb"
+  integrity sha512-01omzJAYRxXdG2/he/+xy+c8a8gCydoQ1yOxnWNcRhrrBW5W+RQJ22EK1SaO8tb3WoUsuEw7mJjBozPzihDFjA==
+  dependencies:
+    "@radix-ui/react-compose-refs" "1.1.1"
+    "@radix-ui/react-primitive" "2.0.1"
     "@radix-ui/react-use-callback-ref" "1.1.0"
 
 "@radix-ui/react-id@1.1.0":
@@ -1262,12 +1307,28 @@
     "@radix-ui/react-primitive" "2.0.0"
     "@radix-ui/react-use-layout-effect" "1.1.0"
 
+"@radix-ui/react-portal@1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-portal/-/react-portal-1.1.3.tgz#b0ea5141103a1671b715481b13440763d2ac4440"
+  integrity sha512-NciRqhXnGojhT93RPyDaMPfLH3ZSl4jjIFbZQ1b/vxvZEdHsBZ49wP9w8L3HzUQwep01LcWtkUvm0OVB5JAHTw==
+  dependencies:
+    "@radix-ui/react-primitive" "2.0.1"
+    "@radix-ui/react-use-layout-effect" "1.1.0"
+
 "@radix-ui/react-presence@1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-presence/-/react-presence-1.1.1.tgz#98aba423dba5e0c687a782c0669dcd99de17f9b1"
   integrity sha512-IeFXVi4YS1K0wVZzXNrbaaUvIJ3qdY+/Ih4eHFhWA9SwGR9UDX7Ck8abvL57C4cv3wwMvUE0OG69Qc3NCcTe/A==
   dependencies:
     "@radix-ui/react-compose-refs" "1.1.0"
+    "@radix-ui/react-use-layout-effect" "1.1.0"
+
+"@radix-ui/react-presence@1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-presence/-/react-presence-1.1.2.tgz#bb764ed8a9118b7ec4512da5ece306ded8703cdc"
+  integrity sha512-18TFr80t5EVgL9x1SwF/YGtfG+l0BS0PRAlCWBDoBEiDQjeKgnNZRVJp/oVBl24sr3Gbfwc/Qpj4OcWTQMsAEg==
+  dependencies:
+    "@radix-ui/react-compose-refs" "1.1.1"
     "@radix-ui/react-use-layout-effect" "1.1.0"
 
 "@radix-ui/react-primitive@2.0.0":
@@ -5322,6 +5383,14 @@ react-remove-scroll-bar@^2.3.6:
     react-style-singleton "^2.2.1"
     tslib "^2.0.0"
 
+react-remove-scroll-bar@^2.3.7:
+  version "2.3.8"
+  resolved "https://registry.yarnpkg.com/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz#99c20f908ee467b385b68a3469b4a3e750012223"
+  integrity sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==
+  dependencies:
+    react-style-singleton "^2.2.2"
+    tslib "^2.0.0"
+
 react-remove-scroll@2.6.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/react-remove-scroll/-/react-remove-scroll-2.6.0.tgz#fb03a0845d7768a4f1519a99fdb84983b793dc07"
@@ -5331,6 +5400,17 @@ react-remove-scroll@2.6.0:
     react-style-singleton "^2.2.1"
     tslib "^2.1.0"
     use-callback-ref "^1.3.0"
+    use-sidecar "^1.1.2"
+
+react-remove-scroll@^2.6.1:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/react-remove-scroll/-/react-remove-scroll-2.6.2.tgz#2518d2c5112e71ea8928f1082a58459b5c7a2a97"
+  integrity sha512-KmONPx5fnlXYJQqC62Q+lwIeAk64ws/cUw6omIumRzMRPqgnYqhSSti99nbj0Ry13bv7dF+BKn7NB+OqkdZGTw==
+  dependencies:
+    react-remove-scroll-bar "^2.3.7"
+    react-style-singleton "^2.2.1"
+    tslib "^2.1.0"
+    use-callback-ref "^1.3.3"
     use-sidecar "^1.1.2"
 
 react-router-dom@^6.28.0:
@@ -5364,6 +5444,14 @@ react-style-singleton@^2.2.1:
   dependencies:
     get-nonce "^1.0.0"
     invariant "^2.2.4"
+    tslib "^2.0.0"
+
+react-style-singleton@^2.2.2:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/react-style-singleton/-/react-style-singleton-2.2.3.tgz#4265608be69a4d70cfe3047f2c6c88b2c3ace388"
+  integrity sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==
+  dependencies:
+    get-nonce "^1.0.0"
     tslib "^2.0.0"
 
 react-transition-group@^4.4.5:
@@ -6057,6 +6145,13 @@ use-callback-ref@^1.3.0:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/use-callback-ref/-/use-callback-ref-1.3.2.tgz#6134c7f6ff76e2be0b56c809b17a650c942b1693"
   integrity sha512-elOQwe6Q8gqZgDA8mrh44qRTQqpIHDcZ3hXTLjBe1i4ph8XpNJnO+aQf3NaG+lriLopI4HMx9VjQLfPQ6vhnoA==
+  dependencies:
+    tslib "^2.0.0"
+
+use-callback-ref@^1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/use-callback-ref/-/use-callback-ref-1.3.3.tgz#98d9fab067075841c5b2c6852090d5d0feabe2bf"
+  integrity sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==
   dependencies:
     tslib "^2.0.0"
 


### PR DESCRIPTION
## 🖇️ 연결 된 이슈

- resolve #19 

## 🏞️ 첨부 파일

<img width="610" alt="image" src="https://github.com/user-attachments/assets/a8a221ef-13a9-4161-b3f0-99e3d2d7b779" />


## 🆕 기능 추가

- React 의 `createPortal` API 를 사용하여 모달 컴포넌트를 html body 로 삽입하도록 구현
- 컴포넌트 마운트시 초기 스타일을 설정해주는 `useInitialStyle` 커스텀 훅 구현
- `ModalContext` 가 관리하는 상태를 `useReducer` 훅으로 구현
  - `useReducer` 는 단순히 현재상태와 액션을 받아 새로운 상태를 반환하면 되므로 테스트에 용이

## 🔍 테스트 사항

- `ModalContext` 와 `useModal` 훅에 대한 단위 테스트 진행
- `StoryBook` 에 대한 UI Test 활성화

