### PR TITLE
Feature#8: 마이페이지 퍼블리싱

### DIFF
--- a/src/apps/Screen.tsx
+++ b/src/apps/Screen.tsx
@@ -1,5 +1,4 @@
 import { NavBottom } from "@/apps/layouts/NavBottom";
-import { NavTop } from "@/apps/layouts/NavTop";
 
 import { AppScreen, AppScreenProps } from "@stackflow/plugin-basic-ui";
 
@@ -14,7 +13,6 @@ export const Screen = ({ children, ...appScreenProps }: AppScreenProps) => {
 export const BaseScreen = ({ children, ...appScreenProps }: AppScreenProps) => {
     return (
         <Screen {...appScreenProps}>
-            <NavTop />
             <div className="screen">{children}</div>
             <NavBottom />
         </Screen>

--- a/src/apps/constants/nav.ts
+++ b/src/apps/constants/nav.ts
@@ -1,22 +1,37 @@
-import { CirclePlus, HeartHandshake, MessagesSquare, User } from "lucide-react";
+import { CirclePlus, HeartHandshake, LucideProps, MessagesSquare, User } from "lucide-react";
 
-export const navBottom = [
+import { ActivityName } from "@/apps/stackflow";
+
+export type NavBottomActivities = Omit<ActivityName, "MatchDetailPage">;
+
+type NavBottomItem = {
+    activityName: NavBottomActivities;
+    path: string;
+    label: string;
+    icon: React.ComponentType<LucideProps>;
+};
+
+export const navBottom: NavBottomItem[] = [
     {
+        activityName: "MatchListPage",
         path: "/match",
         label: "룸메 찾기",
         icon: HeartHandshake,
     },
     {
+        activityName: "CreateMatchPage",
         path: "/match/create",
         label: "룸메 구하기",
         icon: CirclePlus,
     },
     {
+        activityName: "ChatRoomPage",
         path: "/chat",
         label: "채팅",
         icon: MessagesSquare,
     },
     {
+        activityName: "MyPage",
         path: "/mypage",
         label: "마이페이지",
         icon: User,

--- a/src/apps/layouts/NavBottom.tsx
+++ b/src/apps/layouts/NavBottom.tsx
@@ -1,12 +1,20 @@
 import { navBottom } from "@/apps/constants/nav";
+import { ActivityName } from "@/apps/stackflow";
+import { useFlow } from "@/apps/stackflow";
 
 export const NavBottom = () => {
+    const { replace } = useFlow();
+
     return (
         <nav className="w-full max-w-[500px] h-[70px] sticky bottom-0 z-30 bg-white shadow-2xl shadow-black">
             <ul className="flex justify-around w-full h-full gap-4 px-2 bg-white ">
                 {navBottom.map((item, index) => {
                     return (
-                        <li className="flex items-center h-full" key={index}>
+                        <li
+                            key={index}
+                            className="flex items-center h-full"
+                            onClick={() => replace(item.activityName as ActivityName, {})}
+                        >
                             <button className="flex flex-col items-center">
                                 <item.icon size={25} />
                                 <p className="text-sm">{item.label}</p>

--- a/src/apps/stackflow.tsx
+++ b/src/apps/stackflow.tsx
@@ -1,6 +1,8 @@
 import SignInPage from "@/pages/auth/SignInPage";
 import SignUpPage from "@/pages/auth/SignUpPage";
+import ChatRoomPage from "@/pages/chat/ChatRoomPage";
 import HomePage from "@/pages/home/HomePage";
+import CreateMatchPage from "@/pages/match/CreateMatchPage";
 import MatchDetailPage from "@/pages/match/MatchDetailPage";
 import MatchListPage from "@/pages/match/MatchListPage";
 import MyPage from "@/pages/mypage/MyPage";
@@ -10,7 +12,7 @@ import { historySyncPlugin } from "@stackflow/plugin-history-sync";
 import { basicRendererPlugin } from "@stackflow/plugin-renderer-basic";
 import { stackflow } from "@stackflow/react";
 
-export const { Stack, useFlow } = stackflow({
+const stackflowApp = stackflow({
     transitionDuration: 250,
     plugins: [
         basicRendererPlugin(),
@@ -20,10 +22,16 @@ export const { Stack, useFlow } = stackflow({
         historySyncPlugin({
             routes: {
                 HomePage: "/",
+
                 SignInPage: "/auth/signin",
                 SignUpPage: "/auth/signup",
+
                 MatchListPage: "/match",
+                CreateMatchPage: "/match/new",
                 MatchDetailPage: "/match/detail",
+
+                ChatRoomPage: "/chat",
+
                 MyPage: "/mypage",
             },
             fallbackActivity: () => "HomePage",
@@ -32,11 +40,20 @@ export const { Stack, useFlow } = stackflow({
 
     activities: {
         HomePage,
+
         SignInPage,
         SignUpPage,
+
         MatchListPage,
+        CreateMatchPage,
         MatchDetailPage,
+
+        ChatRoomPage,
+
         MyPage,
     },
     initialActivity: () => "HomePage",
 });
+
+export const { Stack, useFlow } = stackflowApp;
+export type ActivityName = keyof typeof stackflowApp.activities;

--- a/src/apps/stackflow.tsx
+++ b/src/apps/stackflow.tsx
@@ -3,6 +3,7 @@ import SignUpPage from "@/pages/auth/SignUpPage";
 import HomePage from "@/pages/home/HomePage";
 import MatchDetailPage from "@/pages/match/MatchDetailPage";
 import MatchListPage from "@/pages/match/MatchListPage";
+import MyPage from "@/pages/mypage/MyPage";
 
 import { basicUIPlugin } from "@stackflow/plugin-basic-ui";
 import { historySyncPlugin } from "@stackflow/plugin-history-sync";
@@ -23,6 +24,7 @@ export const { Stack, useFlow } = stackflow({
                 SignUpPage: "/auth/signup",
                 MatchListPage: "/match",
                 MatchDetailPage: "/match/detail",
+                MyPage: "/mypage",
             },
             fallbackActivity: () => "HomePage",
         }),
@@ -34,6 +36,7 @@ export const { Stack, useFlow } = stackflow({
         SignUpPage,
         MatchListPage,
         MatchDetailPage,
+        MyPage,
     },
     initialActivity: () => "HomePage",
 });

--- a/src/features/mypage/ui/Menu.stories.tsx
+++ b/src/features/mypage/ui/Menu.stories.tsx
@@ -1,0 +1,28 @@
+import { KeyRound, LogOut, UserRoundPen } from "lucide-react";
+
+import { Menu } from "./Menu";
+import { MenuItem } from "@/features/mypage/ui/MenuItem";
+import type { Meta, StoryObj } from "@storybook/react";
+
+const meta: Meta<typeof Menu> = {
+    title: "Features/MyPage/Menu",
+    component: Menu,
+};
+
+export default meta;
+type Story = StoryObj<typeof Menu>;
+
+export const Default: Story = {
+    args: {
+        label: "내 정보 관리",
+    },
+    render: (args) => {
+        return (
+            <Menu label={args.label}>
+                <MenuItem label="비밀번호 변경하기" icon={<KeyRound size={20} />} />
+                <MenuItem label="프로필 관리하기" icon={<UserRoundPen size={20} />} />
+                <MenuItem label="로그아웃" icon={<LogOut size={20} />} />
+            </Menu>
+        );
+    },
+};

--- a/src/features/mypage/ui/Menu.tsx
+++ b/src/features/mypage/ui/Menu.tsx
@@ -1,0 +1,13 @@
+export interface MenuProps {
+    label?: string;
+    children?: React.ReactNode;
+}
+
+export const Menu = ({ label, children }: MenuProps) => {
+    return (
+        <article className="flex flex-col gap-4 py-4">
+            {label && <h2 className="text-lg font-bold text-primary">{label}</h2>}
+            {children}
+        </article>
+    );
+};

--- a/src/features/mypage/ui/MenuItem.stories.tsx
+++ b/src/features/mypage/ui/MenuItem.stories.tsx
@@ -1,0 +1,19 @@
+import { KeyRound } from "lucide-react";
+
+import { MenuItem } from "@/features/mypage/ui/MenuItem";
+import type { Meta, StoryObj } from "@storybook/react";
+
+const meta: Meta<typeof MenuItem> = {
+    title: "Features/MyPage/MenuItem",
+    component: MenuItem,
+};
+
+export default meta;
+type Story = StoryObj<typeof MenuItem>;
+
+export const Default: Story = {
+    args: {
+        label: "비밀번호 변경하기",
+        icon: <KeyRound size={20} />,
+    },
+};

--- a/src/features/mypage/ui/MenuItem.tsx
+++ b/src/features/mypage/ui/MenuItem.tsx
@@ -1,0 +1,13 @@
+export interface MenuItemProps {
+    label: string;
+    icon?: React.ReactNode;
+}
+
+export const MenuItem = ({ label, icon }: MenuItemProps) => {
+    return (
+        <div className="flex items-center gap-2">
+            <span>{icon}</span>
+            <span className="font-semibold">{label}</span>
+        </div>
+    );
+};

--- a/src/features/mypage/ui/ProfileHeader.stories.tsx
+++ b/src/features/mypage/ui/ProfileHeader.stories.tsx
@@ -1,0 +1,17 @@
+import { ProfileHeader } from "@/features/mypage/ui/ProfileHeader";
+import type { Meta, StoryObj } from "@storybook/react";
+
+const meta: Meta<typeof ProfileHeader> = {
+    title: "Features/MyPage/ProfileHeader",
+    component: ProfileHeader,
+};
+
+export default meta;
+type Story = StoryObj<typeof ProfileHeader>;
+
+export const Default: Story = {
+    args: {
+        nickname: "toothlessKid",
+        email: "toothless@knu.ac.kr",
+    },
+};

--- a/src/features/mypage/ui/ProfileHeader.tsx
+++ b/src/features/mypage/ui/ProfileHeader.tsx
@@ -1,0 +1,18 @@
+import { Pencil } from "lucide-react";
+
+export interface ProfileHeaderProps {
+    nickname: string;
+    email: string;
+}
+
+export const ProfileHeader = ({ nickname, email }: ProfileHeaderProps) => {
+    return (
+        <article className="p-4 border border-gray-200 rounded-md">
+            <h1 className="inline-flex items-center gap-2 text-lg font-bold">
+                <span className="text-primary">{nickname}</span>
+                <Pencil size={16} className="text-gray-500" />
+            </h1>
+            <p className="text-xs text-gray-700">{email}</p>
+        </article>
+    );
+};

--- a/src/features/mypage/ui/index.ts
+++ b/src/features/mypage/ui/index.ts
@@ -1,0 +1,3 @@
+export * from "./ProfileHeader";
+export * from "./Menu";
+export * from "./MenuItem";

--- a/src/pages/match/CreateMatchPage.tsx
+++ b/src/pages/match/CreateMatchPage.tsx
@@ -1,0 +1,5 @@
+import { BaseScreen } from "@/apps/Screen";
+
+export default function CreateMatchPage() {
+    return <BaseScreen>create match page</BaseScreen>;
+}

--- a/src/pages/match/MatchDetailPage.tsx
+++ b/src/pages/match/MatchDetailPage.tsx
@@ -12,10 +12,8 @@ import { BackDropImage } from "@/shared/components/BackDropImage";
 import { NavPrevious } from "@/shared/components/NavPrevious";
 import { ActivityComponentType } from "@stackflow/react";
 
-// import { fetchAnswerResponse } from "@/__mocks__/fetchAnswerResponse";
-
 export interface MatchDetailPageParams {
-    id: number;
+    id?: number;
 }
 
 const MatchDetailPage: ActivityComponentType<MatchDetailPageParams> = ({ params }) => {
@@ -23,9 +21,8 @@ const MatchDetailPage: ActivityComponentType<MatchDetailPageParams> = ({ params 
 
     console.log("id : ", params.id);
 
-    const mock__matchDetailResponse = fetchMatchDetail(params.id);
-    // const mock__answerResponse = fetchAnswerResponse(params.id);
-    const mock__answerResponseByUserId = fetchAnswerByUserId(params.id);
+    const mock__matchDetailResponse = fetchMatchDetail(params.id as number);
+    const mock__answerResponseByUserId = fetchAnswerByUserId(params.id as number);
 
     return (
         <BaseScreen>

--- a/src/pages/match/MatchListPage.tsx
+++ b/src/pages/match/MatchListPage.tsx
@@ -1,4 +1,5 @@
 import { BaseScreen } from "@/apps/Screen";
+import { NavTop } from "@/apps/layouts/NavTop";
 import { useFlow } from "@/apps/stackflow";
 
 import { MatchListItem } from "@/features/match/ui/MatchListItem";
@@ -58,6 +59,7 @@ export default function MatchListPage() {
 
     return (
         <BaseScreen>
+            <NavTop />
             <div>
                 {dummyData.map((data) => {
                     return (

--- a/src/pages/mypage/MyPage.tsx
+++ b/src/pages/mypage/MyPage.tsx
@@ -1,0 +1,47 @@
+import {
+    Bug,
+    FileQuestion,
+    Info,
+    KeyRound,
+    LogOut,
+    Scroll,
+    UserRoundPen,
+    UserX,
+} from "lucide-react";
+
+import { BaseScreen } from "@/apps/Screen";
+import { NavTop } from "@/apps/layouts/NavTop";
+
+import { Menu } from "@/features/mypage/ui/Menu";
+import { MenuItem } from "@/features/mypage/ui/MenuItem";
+import { ProfileHeader } from "@/features/mypage/ui/ProfileHeader";
+
+export default function MyPage() {
+    return (
+        <BaseScreen>
+            <NavTop />
+
+            <section className="p-4">
+                <ProfileHeader nickname={"toothlessKid"} email={"toothless@knu.ac.kr"} />
+
+                <Menu label="내 정보 관리">
+                    <MenuItem label="비밀번호 변경하기" icon={<KeyRound size={20} />} />
+                    <MenuItem label="프로필 관리하기" icon={<UserRoundPen size={20} />} />
+                    <MenuItem label="로그아웃" icon={<LogOut size={20} />} />
+                </Menu>
+
+                <Menu label="고객센터">
+                    <MenuItem label="문의하기" icon={<FileQuestion size={20} />} />
+                    <MenuItem label="건의사항" icon={<UserRoundPen size={20} />} />
+                    <MenuItem label="버그신고" icon={<Bug size={20} />} />
+                </Menu>
+
+                <Menu label="기타">
+                    <MenuItem label="개인정보 처리방침" icon={<Info size={20} />} />
+                    <MenuItem label="서비스 이용약관" icon={<Scroll size={20} />} />
+                    <MenuItem label="탈퇴하기" icon={<UserX size={20} />} />
+                </Menu>
+            </section>
+        </BaseScreen>
+    );
+}


### PR DESCRIPTION
## 🖇️ 연결 된 이슈

- resolve #8

## 🏞️ 첨부 파일

<img width="313" alt="image" src="https://github.com/user-attachments/assets/44e98a44-2d96-4ff4-a7d6-b1258989ba5f" />


## 🆕 기능 추가

- `MyPage` 퍼블리싱
  - `MenuItem` 컴포넌트 구현
  - `Menu` 컴포넌트 구현
  - `ProfileHeader` 컴포넌트 구현

## 📋 변경 사항

- `NavBottom` `onClick` 시에 activity 전환 기능 추가
- `MatchLiatPage` 에만 `NavTop` 컴포넌트가 보이도록 수정
- 사용하지 않는 `mockData` 제거
- `CreateMatchPage` 기본 페이지 레이아웃 구현

