### PR TITLE
Feature#6: 핏글 생성 페이지 퍼블리싱

### DIFF
--- a/src/pages/match/CreateMatchPage.tsx
+++ b/src/pages/match/CreateMatchPage.tsx
@@ -1,5 +1,45 @@
 import { BaseScreen } from "@/apps/Screen";
+import { NavTop } from "@/apps/layouts/NavTop";
 
+import { Button, Input, Label, Textarea } from "@/shared/ui";
+
+/**
+ * [ ] 이미 생성된 핏글이 있는지 확인 후, 없으면 생성
+ * [ ] 있으면 '이미 작성한 핏글이 있어용' 메시지 출력 후 작성한 핏글로 이동
+ */
 export default function CreateMatchPage() {
-    return <BaseScreen>create match page</BaseScreen>;
+    return (
+        <BaseScreen>
+            <NavTop />
+
+            <section className="flex flex-col gap-2 p-4">
+                <div>
+                    <h1 className="text-2xl font-bold">핏글 생성하기</h1>
+                    <p>룸메이트 모집을 위한 핏글을 생성해요</p>
+                </div>
+
+                <div>
+                    <Label htmlFor="title" className="block my-2">
+                        핏글 제목
+                    </Label>
+                    <Input id="title" type="text" placeholder="핏글의 제목을 입력해주세요" />
+                </div>
+
+                <div>
+                    <Label htmlFor="description" className="block my-2">
+                        핏글 설명
+                    </Label>
+                    <Textarea
+                        id="description"
+                        placeholder="핏글에 대한 설명을 입력해주세요"
+                        className="h-40 resize-none"
+                    />
+                </div>
+
+                <div>
+                    <Button className="w-full">핏글 생성하기</Button>
+                </div>
+            </section>
+        </BaseScreen>
+    );
 }

--- a/src/shared/ui/index.ts
+++ b/src/shared/ui/index.ts
@@ -13,3 +13,4 @@ export * from "./toggle-group";
 export * from "./toggle";
 export * from "./label";
 export * from "./dialog";
+export * from "./textarea";

--- a/src/shared/ui/textarea.tsx
+++ b/src/shared/ui/textarea.tsx
@@ -1,0 +1,22 @@
+import * as React from "react"
+
+import { cn } from "@/shared/lib/utils"
+
+const Textarea = React.forwardRef<
+  HTMLTextAreaElement,
+  React.ComponentProps<"textarea">
+>(({ className, ...props }, ref) => {
+  return (
+    <textarea
+      className={cn(
+        "flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        className
+      )}
+      ref={ref}
+      {...props}
+    />
+  )
+})
+Textarea.displayName = "Textarea"
+
+export { Textarea }


### PR DESCRIPTION
## 🖇️ 연결 된 이슈

- resolve #6

## 🏞️ 첨부 파일

<img width="314" alt="image" src="https://github.com/user-attachments/assets/df264dc3-817d-40ef-9562-9f8e0eaababa" />

## 🆕 기능 추가

- 핏글 생성 페이지 퍼블리싱

## 📋 변경 사항

- `shadcn/textarea` 컴포넌트 추가 및 진입점 설정
