### PR TITLE
Design#53: 로그인 페이지 디자인 변경사항 적용

### DIFF
--- a/src/pages/auth/SignInPage.stories.tsx
+++ b/src/pages/auth/SignInPage.stories.tsx
@@ -1,0 +1,19 @@
+import SignInPage from "@/pages/auth/SignInPage";
+
+import type { Meta, StoryObj } from "@storybook/react";
+
+const meta: Meta<typeof SignInPage> = {
+    title: "Pages/SignInPage (로그인 페이지)",
+    component: SignInPage,
+    parameters: {
+        defaultViewport: "mobile1",
+        layout: "fullscreen",
+    },
+};
+
+export default meta;
+type Story = StoryObj<typeof SignInPage>;
+
+export const Default: Story = {
+    args: {},
+};

--- a/src/pages/auth/SignInPage.tsx
+++ b/src/pages/auth/SignInPage.tsx
@@ -3,46 +3,48 @@ import { ChevronLeft } from "lucide-react";
 import { Screen } from "@/apps/Screen";
 import { useFlow } from "@/apps/stackflow";
 
-import { Button, Input, Label } from "@/shared/ui";
+import { InputWithLabel } from "@/shared/components/InputWithLabel/InputWithLabel";
+import { Button } from "@/shared/ui";
 
 export default function SignInPage() {
     const { pop } = useFlow();
 
     return (
         <Screen>
-            <article className="flex flex-col justify-between h-full p-4">
+            <article className="flex flex-col justify-between h-[100dvh] p-4">
                 <section className="flex flex-col gap-2">
                     <ChevronLeft size={24} className="h-8" onClick={() => pop()} />
 
                     <div>
-                        <h1 className="my-2 text-2xl font-bold">로그인</h1>
-                        <Label htmlFor="email" className="font-semibold">
-                            아이디 (이메일)
-                        </Label>
-                        <Input
+                        <h1 className="my-2 text-xl font-bold">로그인</h1>
+
+                        <InputWithLabel
                             id="email"
+                            label="아이디 (이메일)"
                             type="email"
-                            placeholder="아이디(이메일)을 입력해주세요"
+                            placeholder="roomfit@knu.ac.kr"
+                            className="mb-2"
                         />
 
-                        <Label htmlFor="password" className="font-semibold">
-                            비밀번호
-                        </Label>
-                        <Input
+                        <InputWithLabel
                             id="password"
+                            label="비밀번호"
                             type="password"
                             placeholder="비밀번호를 입력해주세요"
                         />
+
+                        <p className="my-1 text-sm text-left">
+                            비밀번호를 잊으셨나요?
+                            <span className="ml-1 font-semibold underline">비밀번호 찾기</span>
+                        </p>
                     </div>
                 </section>
 
-                <section className="flex flex-col gap-2">
-                    <p className="text-center">
-                        비밀번호를 잊으셨나요?
-                        <span className="ml-1 font-semibold text-primary">비밀번호 찾기</span>
-                    </p>
-                    <Button>로그인</Button>
-                    <Button variant="outline">회원가입</Button>
+                <section className="flex gap-2 pb-2">
+                    <Button variant="secondary" className="w-full border-[1px] border-primary">
+                        회원가입
+                    </Button>
+                    <Button className="w-full">로그인</Button>
                 </section>
             </article>
         </Screen>

--- a/src/pages/home/HomePage.stories.tsx
+++ b/src/pages/home/HomePage.stories.tsx
@@ -3,7 +3,7 @@ import HomePage from "@/pages/home/HomePage";
 import type { Meta, StoryObj } from "@storybook/react";
 
 const meta: Meta<typeof HomePage> = {
-    title: "Pages/HomePage",
+    title: "Pages/HomePage (메인 페이지)",
     component: HomePage,
     parameters: {
         defaultViewport: "mobile1",

--- a/src/shared/components/InputWithLabel/InputWithLabel.stories.tsx
+++ b/src/shared/components/InputWithLabel/InputWithLabel.stories.tsx
@@ -1,0 +1,18 @@
+import { InputWithLabel } from "@/shared/components/InputWithLabel/InputWithLabel";
+import type { Meta, StoryObj } from "@storybook/react";
+
+const meta: Meta<typeof InputWithLabel> = {
+    title: "Form/InputWithLabel",
+    component: InputWithLabel,
+};
+
+export default meta;
+type Story = StoryObj<typeof InputWithLabel>;
+
+export const Default: Story = {
+    args: {
+        id: "email",
+        label: "아이디 (이메일)",
+        placeholder: "roomfit@knu.ac.kr",
+    },
+};

--- a/src/shared/components/InputWithLabel/InputWithLabel.tsx
+++ b/src/shared/components/InputWithLabel/InputWithLabel.tsx
@@ -1,0 +1,22 @@
+import { forwardRef } from "react";
+import { Fragment } from "react/jsx-runtime";
+
+import { Input, Label } from "@/shared/ui";
+
+export interface InputWithLabelProps extends React.ComponentProps<"input"> {
+    id?: string;
+    label: string;
+}
+
+export const InputWithLabel = forwardRef<HTMLInputElement, InputWithLabelProps>(
+    ({ id, label, ...props }) => {
+        return (
+            <Fragment>
+                <Label htmlFor={id} className="my-1 text-base font-normal">
+                    {label}
+                </Label>
+                <Input id={id} {...props} />
+            </Fragment>
+        );
+    },
+);


### PR DESCRIPTION
## 🖇️ 연결 된 이슈

- resolve #53

## 🏞️ 첨부 파일

<img width="320" alt="image" src="https://github.com/user-attachments/assets/6e7ae4fc-0c40-4fe7-834b-14ef1222acfb" />


## 📋 변경 사항

- 페이지 단위의 스토리에 한글 title 설명추가
- 로그인 페이지 디자인 변경사항 적용
- `InputWithLabel` 공통 컴포넌트 분리
