### PR TITLE
Design#65: Slider `background-color` 를 `#EFEFEF` 로 수정

### DIFF
--- a/src/pages/auth/SignInPage.tsx
+++ b/src/pages/auth/SignInPage.tsx
@@ -38,13 +38,13 @@ export default function SignInPage() {
                             <span className="ml-1 font-semibold underline">비밀번호 찾기</span>
                         </p>
                     </div>
-                </section>
 
-                <section className="flex gap-2 pb-2">
-                    <Button variant="secondary" className="w-full border-[1px] border-primary">
-                        회원가입
-                    </Button>
-                    <Button className="w-full">로그인</Button>
+                    <div className="flex gap-2">
+                        <Button className="w-full">로그인</Button>
+                        <Button variant="secondary" className="w-full border-[1px] border-primary">
+                            회원가입
+                        </Button>
+                    </div>
                 </section>
             </article>
         </Screen>

--- a/src/pages/auth/SignUpVerifySection.tsx
+++ b/src/pages/auth/SignUpVerifySection.tsx
@@ -15,36 +15,43 @@ export default function SignUpVerifySection() {
                     <ChevronLeft size={24} className="h-8" onClick={() => pop()} />
 
                     <div className="flex flex-col gap-2">
-                        <h1 className="my-2 text-2xl font-bold">회원가입</h1>
+                        <h1 className="my-2 text-xl font-bold">회원가입</h1>
 
-                        <Label htmlFor="email" className="font-semibold">
-                            아이디 (이메일)
-                        </Label>
-                        <div className="flex gap-2">
-                            <Input
-                                id="email"
-                                type="email"
-                                placeholder="아이디(이메일)을 입력해주세요"
-                                className="flex-grow-[6]]"
-                            />
-                            <Button className="flex-grow-[1]">인증하기</Button>
-                        </div>
-
-                        <Label htmlFor="verification-code" className="font-semibold">
-                            인증번호
-                        </Label>
-                        <div className="flex gap-2">
-                            <Input
-                                id="verification-code"
-                                type="verification-code"
-                                placeholder="인증번호"
-                                className="flex-grow-[6]]"
-                            />
-                            <Button className="flex-grow-[1]">확인하기</Button>
+                        <div>
+                            <Label htmlFor="email" className="my-1 text-base font-normal">
+                                아이디 (이메일)
+                            </Label>
+                            <div className="flex gap-2">
+                                <Input
+                                    id="email"
+                                    type="email"
+                                    placeholder="아이디(이메일)을 입력해주세요"
+                                    className="flex-grow-[6]"
+                                />
+                                <Button className="flex-grow-[1]">인증하기</Button>
+                            </div>
                         </div>
 
                         <div>
-                            <Label htmlFor="password" className="font-semibold">
+                            <Label
+                                htmlFor="verification-code"
+                                className="my-1 text-base font-normal"
+                            >
+                                인증번호
+                            </Label>
+                            <div className="flex gap-2">
+                                <Input
+                                    id="verification-code"
+                                    type="verification-code"
+                                    placeholder="인증번호"
+                                    className="flex-grow-[6]"
+                                />
+                                <Button className="flex-grow-[1]">확인하기</Button>
+                            </div>
+                        </div>
+
+                        <div>
+                            <Label htmlFor="password" className="my-1 text-base font-normal">
                                 비밀번호
                             </Label>
                             <Input
@@ -55,7 +62,7 @@ export default function SignUpVerifySection() {
                         </div>
 
                         <div>
-                            <Label htmlFor="password" className="font-semibold">
+                            <Label htmlFor="password" className="my-1 text-base font-normal">
                                 비밀번호 확인
                             </Label>
                             <Input
@@ -64,12 +71,23 @@ export default function SignUpVerifySection() {
                                 placeholder="비밀번호를 입력해주세요"
                             />
                         </div>
+
+                        <div className="flex gap-2 my-1">
+                            <Button
+                                variant="secondary"
+                                className="w-full border-[1px] border-primary"
+                            >
+                                이전
+                            </Button>
+                            <Button
+                                className="w-full"
+                                onClick={() => push("SignUpPage", { section: 2 })}
+                            >
+                                다음
+                            </Button>
+                        </div>
                     </div>
                 </section>
-
-                <Button className="w-full" onClick={() => push("SignUpPage", { section: 2 })}>
-                    다음
-                </Button>
             </article>
         </Screen>
     );

--- a/src/shared/ui/slider.tsx
+++ b/src/shared/ui/slider.tsx
@@ -12,7 +12,7 @@ const Slider = React.forwardRef<
         className={cn("relative flex w-full touch-none select-none items-center", className)}
         {...props}
     >
-        <SliderPrimitive.Track className="relative w-full h-[6px] overflow-hidden rounded-full grow bg-[#FED7D7]">
+        <SliderPrimitive.Track className="relative w-full h-[6px] overflow-hidden rounded-full grow bg-dark-100">
             <SliderPrimitive.Range className="absolute h-full bg-primary" />
         </SliderPrimitive.Track>
         <SliderPrimitive.Thumb className="block w-5 h-5 transition-colors rounded-full shadow-md border-primary bg-background ring-offset-background focus-visible:outline-none focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50" />
@@ -37,7 +37,7 @@ const DualRangeSlider = React.forwardRef<
             className={cn("relative flex w-full touch-none select-none items-center", className)}
             {...props}
         >
-            <SliderPrimitive.Track className="relative w-full h-2 overflow-hidden rounded-full grow bg-secondary bg-[#FED7D7]">
+            <SliderPrimitive.Track className="relative w-full h-2 overflow-hidden rounded-full grow bg-dark-100">
                 <SliderPrimitive.Range className="absolute h-full bg-primary" />
             </SliderPrimitive.Track>
             {initialValue.map((value, index) => (

--- a/src/shared/ui/slider.tsx
+++ b/src/shared/ui/slider.tsx
@@ -12,7 +12,7 @@ const Slider = React.forwardRef<
         className={cn("relative flex w-full touch-none select-none items-center", className)}
         {...props}
     >
-        <SliderPrimitive.Track className="relative w-full h-[6px] overflow-hidden rounded-full grow bg-dark-100">
+        <SliderPrimitive.Track className="relative w-full h-2 overflow-hidden rounded-full grow bg-dark-100">
             <SliderPrimitive.Range className="absolute h-full bg-primary" />
         </SliderPrimitive.Track>
         <SliderPrimitive.Thumb className="block w-5 h-5 transition-colors rounded-full shadow-md border-primary bg-background ring-offset-background focus-visible:outline-none focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50" />


### PR DESCRIPTION
## 🖇️ 연결 된 이슈

- resolve #61 
- resolve #65

## 🏞️ 첨부 파일

- `Slider`
<img width="400" alt="image" src="https://github.com/user-attachments/assets/ae7cfbc1-e28a-4ede-a03f-32fb640aec00" />

- `DoubleSlider`
<img width="400" alt="image" src="https://github.com/user-attachments/assets/ad424117-a062-40e1-ba7e-fbace1a5aa8d" />

## 📋 변경 사항

- 회원가입 페이지 디자인 변경사항 적용
- 로그인 페이지 버튼을 Input 하단으로 위치 변경
- `Slider`, `DoubleSlider` 컴포넌트의 배경색상을 `#EFEFEF (bg-dark-100)` 로 변경하였습니다