### PR TITLE
Feature#70: 룸핏 모집공고 상세페이지 디자인 변경사항 적용

### DIFF
--- a/src/apps/stackflow.tsx
+++ b/src/apps/stackflow.tsx
@@ -6,6 +6,7 @@ import CreateMatchPage from "@/pages/match/CreateMatchPage";
 import MatchDetailPage from "@/pages/match/MatchDetailPage";
 import MatchListPage from "@/pages/match/MatchListPage";
 import MyPage from "@/pages/mypage/MyPage";
+import ProfileDetailPage from "@/pages/profile/ProfileDetailPage";
 
 import { basicUIPlugin } from "@stackflow/plugin-basic-ui";
 import { historySyncPlugin } from "@stackflow/plugin-history-sync";
@@ -33,6 +34,7 @@ const stackflowApp = stackflow({
                 ChatRoomPage: "/chat",
 
                 MyPage: "/mypage",
+                ProfileDetailPage: "/profile/detail",
             },
             fallbackActivity: () => "HomePage",
         }),
@@ -51,6 +53,7 @@ const stackflowApp = stackflow({
         ChatRoomPage,
 
         MyPage,
+        ProfileDetailPage,
     },
     initialActivity: () => "HomePage",
 });

--- a/src/apps/styles/tailwind.css
+++ b/src/apps/styles/tailwind.css
@@ -48,6 +48,9 @@
     .bg-dark-100 {
         background-color: var(--dark-100);
     }
+    .bg-dark-100\/50 {
+        background-color: rgba(239, 239, 239, 0.5);
+    }
 
     :root {
         --background: #fff;

--- a/src/entities/profile/ui/ProfileCard/ProfileCard.tsx
+++ b/src/entities/profile/ui/ProfileCard/ProfileCard.tsx
@@ -1,5 +1,7 @@
 import { ChevronRight } from "lucide-react";
 
+import { useFlow } from "@/apps/stackflow";
+
 import { ProfileCardDecorator } from "@/entities/profile/assets/ProfileCardDecorator";
 import { ProfileCardLogo } from "@/entities/profile/assets/ProfileCardLogo";
 import { cn } from "@/shared/lib";
@@ -15,9 +17,19 @@ export interface ProfileCardProps {
     mbti: string;
 }
 
-export const ProfileCard = ({ className, name, studentId, birthYear, mbti }: ProfileCardProps) => {
+export const ProfileCard = ({
+    className,
+    id,
+    name,
+    studentId,
+    birthYear,
+    mbti,
+}: ProfileCardProps) => {
+    const { push } = useFlow();
+
     return (
         <div
+            onClick={() => push("ProfileDetailPage", { id })}
             className={cn(className, "relative flex p-4 overflow-hidden rounded-lg")}
             style={{
                 background: "linear-gradient(to bottom, #5DA5FF 0%, #0675FF 56%)",

--- a/src/entities/profile/ui/ProfileGroup/ProfileGroup.stories.tsx
+++ b/src/entities/profile/ui/ProfileGroup/ProfileGroup.stories.tsx
@@ -1,0 +1,16 @@
+import { ProfileGroup } from "@/entities/profile/ui/ProfileGroup/ProfileGroup";
+import type { Meta, StoryObj } from "@storybook/react";
+
+const meta: Meta<typeof ProfileGroup> = {
+    title: "ProfileGroup",
+    component: ProfileGroup,
+};
+
+export default meta;
+type Story = StoryObj<typeof ProfileGroup>;
+
+export const Default: Story = {
+    args: {
+        className: "w-[400px] h-[400px]",
+    },
+};

--- a/src/entities/profile/ui/ProfileGroup/ProfileGroup.tsx
+++ b/src/entities/profile/ui/ProfileGroup/ProfileGroup.tsx
@@ -1,0 +1,10 @@
+import { cn } from "@/shared/lib";
+
+export interface ProfileGroupProps {
+    className?: string;
+    children?: React.ReactNode;
+}
+
+export const ProfileGroup = ({ className, children }: ProfileGroupProps) => {
+    return <div className={cn("bg-white rounded-xl", className)}>{children}</div>;
+};

--- a/src/entities/profile/ui/RangeDisplay/RangeDisplay.tsx
+++ b/src/entities/profile/ui/RangeDisplay/RangeDisplay.tsx
@@ -39,7 +39,7 @@ export const RangeDisplay = ({
     }, [maxRange, maxValue, minRange, minValue]);
 
     return (
-        <div className={cn(className, "relative")}>
+        <div className={cn("relative h-9 mt-1", className)}>
             <div className="absolute w-full h-[10px] rounded-full bg-dark-100" />
             <div className="absolute h-[10px] rounded-full bg-primary" ref={rangeDisplayRef} />
             <div className="absolute flex justify-between w-full top-[14px] text-xs font-normal">

--- a/src/entities/profile/ui/TextDisplay/TextDisplay.tsx
+++ b/src/entities/profile/ui/TextDisplay/TextDisplay.tsx
@@ -1,7 +1,14 @@
+import { cn } from "@/shared/lib";
+
 export interface TextDisplayProps {
+    className?: string;
     children?: React.ReactNode;
 }
 
-export const TextDisplay = ({ children }: TextDisplayProps) => {
-    return <div className="px-4 py-2 font-medium rounded-md bg-dark-100">{children}</div>;
+export const TextDisplay = ({ className, children }: TextDisplayProps) => {
+    return (
+        <div className={cn("px-4 py-2 font-medium rounded-md bg-dark-100", className)}>
+            {children}
+        </div>
+    );
 };

--- a/src/pages/match/MatchDetailPage.tsx
+++ b/src/pages/match/MatchDetailPage.tsx
@@ -1,12 +1,9 @@
-import { useState } from "react";
-
 import { BaseScreen } from "@/apps/Screen";
 
-import { fetchAnswerByUserId } from "@/__mocks__/fetchAnswerByUserId";
 import { fetchMatchDetail } from "@/__mocks__/fetchMatchDetail";
+import { ProfileCard } from "@/entities/profile/ui/ProfileCard/ProfileCard";
 import { MatchInfo } from "@/features/match/ui/MatchInfo";
 import defaultImage from "@/shared/assets/bg-background.webp";
-import { Selector } from "@/shared/components";
 import { BackDropImage } from "@/shared/components/BackDropImage";
 import { NavPrevious } from "@/shared/components/NavPrevious";
 import { ActivityComponentType } from "@stackflow/react";
@@ -16,12 +13,7 @@ export interface MatchDetailPageParams {
 }
 
 const MatchDetailPage: ActivityComponentType<MatchDetailPageParams> = ({ params }) => {
-    const [selectedUser, setSelectedUser] = useState<string>("");
-
-    console.log("id : ", params.id);
-
     const mock__matchDetailResponse = fetchMatchDetail(params.id as number);
-    const mock__answerResponseByUserId = fetchAnswerByUserId(params.id as number);
 
     return (
         <BaseScreen>
@@ -38,27 +30,10 @@ const MatchDetailPage: ActivityComponentType<MatchDetailPageParams> = ({ params 
                 />
             </BackDropImage>
 
-            <div className="p-4">
-                <p className="font-bold">참여중인 인원</p>
-                <Selector
-                    placeholder="참여중인 인원을 선택해주세요"
-                    options={[
-                        { label: "홍길동", value: "1" },
-                        { label: "김철수", value: "2" },
-                        { label: "이영희", value: "3" },
-                    ]}
-                    value={selectedUser}
-                    onValueChange={(value) => setSelectedUser(value)}
-                />
-            </div>
-            <div className="p-4">
-                {mock__answerResponseByUserId.map((answer) => {
-                    return (
-                        <div key={answer.questionId}>
-                            <p>{answer.questionText}</p>
-                        </div>
-                    );
-                })}
+            <div className="flex flex-col gap-5 p-6">
+                <ProfileCard id={0} name={"김룸핏"} studentId={20} birthYear={2000} mbti={"ESTP"} />
+                <ProfileCard id={0} name={"김룸핏"} studentId={20} birthYear={2000} mbti={"ESTP"} />
+                <ProfileCard id={0} name={"김룸핏"} studentId={20} birthYear={2000} mbti={"ESTP"} />
             </div>
         </BaseScreen>
     );

--- a/src/pages/profile/ProfileDetailPage.tsx
+++ b/src/pages/profile/ProfileDetailPage.tsx
@@ -1,0 +1,87 @@
+import { BaseScreen } from "@/apps/Screen";
+
+import { ProfileGroup } from "@/entities/profile/ui/ProfileGroup/ProfileGroup";
+import { RangeDisplay } from "@/entities/profile/ui/RangeDisplay/RangeDisplay";
+import { TextDisplay } from "@/entities/profile/ui/TextDisplay/TextDisplay";
+import { NavPrevious } from "@/shared/components";
+import { ToggleButtonGroup } from "@/shared/components/ToggleButtonGroup/ToggleButtonGroup";
+import { Label } from "@/shared/ui";
+
+const options = ["수면환경", "환경정보", "생활 및 관계", "취미 및 활동"];
+
+export default function ProfileDetailPage() {
+    return (
+        <BaseScreen>
+            <NavPrevious />
+
+            <section className="px-6 py-4">
+                <div>
+                    <Label>이름</Label>
+                    <TextDisplay>김룸핏</TextDisplay>
+                </div>
+
+                <div>
+                    <Label>전공</Label>
+                    <TextDisplay>김룸핏</TextDisplay>
+                </div>
+
+                <div>
+                    <Label>학번</Label>
+                    <TextDisplay>김룸핏</TextDisplay>
+                </div>
+
+                <div>
+                    <Label>나이</Label>
+                    <TextDisplay>김룸핏</TextDisplay>
+                </div>
+
+                <ToggleButtonGroup
+                    className="my-4"
+                    options={options}
+                    onChange={(selectedOption) => console.log({ selectedOption })}
+                />
+            </section>
+
+            <section className="p-2 py-4 bg-dark-100">
+                <ProfileGroup className="w-full p-4">
+                    <div>
+                        <Label>기상시간</Label>
+                        <TextDisplay className="bg-dark-100/50">07 ~ 10 시 사이</TextDisplay>
+                    </div>
+
+                    <div>
+                        <Label>취침시간</Label>
+                        <TextDisplay className="bg-dark-100/50">07 ~ 10 시 사이</TextDisplay>
+                    </div>
+
+                    <div>
+                        <Label>잠귀</Label>
+                        <RangeDisplay
+                            minRange={0}
+                            maxRange={5}
+                            minValue={0}
+                            maxValue={3}
+                            minLabel="어두움"
+                            maxLabel="밝음"
+                        />
+                    </div>
+
+                    <div>
+                        <Label>취침등</Label>
+                        <TextDisplay className="bg-dark-100/50">없음</TextDisplay>
+                    </div>
+
+                    <div>
+                        <Label>알람 설정</Label>
+                        <TextDisplay className="bg-dark-100/50">없음</TextDisplay>
+                    </div>
+
+                    <div>
+                        <Label>잠버릇</Label>
+                        <TextDisplay className="bg-dark-100/50">코골이, 이갈이</TextDisplay>
+                    </div>
+                </ProfileGroup>
+            </section>
+        </BaseScreen>
+    );
+}

--- a/src/shared/components/ToggleButtonGroup/ToggleButtonGroup.stories.tsx
+++ b/src/shared/components/ToggleButtonGroup/ToggleButtonGroup.stories.tsx
@@ -11,7 +11,7 @@ const meta: Meta<typeof ToggleButtonGroup> = {
 export default meta;
 type Story = StoryObj<typeof ToggleButtonGroup>;
 
-export const ToggleButtonGroupExample = ({ options }: { options: string[] }) => {
+const ToggleButtonGroupExample = ({ options }: { options: string[] }) => {
     const [option, setOption] = useState("수면환경");
 
     useEffect(() => {

--- a/src/shared/components/ToggleButtonGroup/ToggleButtonGroup.stories.tsx
+++ b/src/shared/components/ToggleButtonGroup/ToggleButtonGroup.stories.tsx
@@ -1,0 +1,31 @@
+import { useEffect, useState } from "react";
+
+import { ToggleButtonGroup } from "@/shared/components/ToggleButtonGroup/ToggleButtonGroup";
+import type { Meta, StoryObj } from "@storybook/react";
+
+const meta: Meta<typeof ToggleButtonGroup> = {
+    title: "Components/Form/ToggleButtonGroup",
+    component: ToggleButtonGroup,
+};
+
+export default meta;
+type Story = StoryObj<typeof ToggleButtonGroup>;
+
+export const ToggleButtonGroupExample = ({ options }: { options: string[] }) => {
+    const [option, setOption] = useState("수면환경");
+
+    useEffect(() => {
+        console.log({ option });
+    }, [option]);
+
+    return <ToggleButtonGroup options={options} onChange={setOption} />;
+};
+
+export const Default: Story = {
+    args: {
+        options: ["수면환경", "환경정보", "생활 및 관계", "취미 및 활동"],
+    },
+    render: (args) => {
+        return <ToggleButtonGroupExample options={args.options} />;
+    },
+};

--- a/src/shared/components/ToggleButtonGroup/ToggleButtonGroup.tsx
+++ b/src/shared/components/ToggleButtonGroup/ToggleButtonGroup.tsx
@@ -1,13 +1,16 @@
 import { useEffect, useState } from "react";
 
 import { ToggleButtonItem } from "@/shared/components/ToggleButtonGroup/ToggleButtonItem";
+import { cn } from "@/shared/lib";
 
 export interface ToggleButtonGroupProps {
+    className?: string;
+
     options: string[];
     onChange: (selectedOption: string) => void;
 }
 
-export const ToggleButtonGroup = ({ options, onChange }: ToggleButtonGroupProps) => {
+export const ToggleButtonGroup = ({ className, options, onChange }: ToggleButtonGroupProps) => {
     const [selectedOption, setSelectedOption] = useState<string>("");
 
     useEffect(() => {
@@ -15,7 +18,7 @@ export const ToggleButtonGroup = ({ options, onChange }: ToggleButtonGroupProps)
     }, [onChange, selectedOption]);
 
     return (
-        <div className="flex gap-2">
+        <div className={cn("flex w-full gap-1", className)}>
             {options.map((option, index) => {
                 return (
                     <ToggleButtonItem

--- a/src/shared/components/ToggleButtonGroup/ToggleButtonGroup.tsx
+++ b/src/shared/components/ToggleButtonGroup/ToggleButtonGroup.tsx
@@ -1,0 +1,31 @@
+import { useEffect, useState } from "react";
+
+import { ToggleButtonItem } from "@/shared/components/ToggleButtonGroup/ToggleButtonItem";
+
+export interface ToggleButtonGroupProps {
+    options: string[];
+    onChange: (selectedOption: string) => void;
+}
+
+export const ToggleButtonGroup = ({ options, onChange }: ToggleButtonGroupProps) => {
+    const [selectedOption, setSelectedOption] = useState<string>("");
+
+    useEffect(() => {
+        onChange(selectedOption as string);
+    }, [onChange, selectedOption]);
+
+    return (
+        <div className="flex gap-2">
+            {options.map((option, index) => {
+                return (
+                    <ToggleButtonItem
+                        key={index}
+                        isSelected={selectedOption === option}
+                        option={option}
+                        setSelectedOption={setSelectedOption}
+                    />
+                );
+            })}
+        </div>
+    );
+};

--- a/src/shared/components/ToggleButtonGroup/ToggleButtonItem.stories.tsx
+++ b/src/shared/components/ToggleButtonGroup/ToggleButtonItem.stories.tsx
@@ -1,0 +1,24 @@
+import { ToggleButtonItem } from "@/shared/components/ToggleButtonGroup/ToggleButtonItem";
+import type { Meta, StoryObj } from "@storybook/react";
+
+const meta: Meta<typeof ToggleButtonItem> = {
+    title: "Components/Form/ToggleButtonItem",
+    component: ToggleButtonItem,
+};
+
+export default meta;
+type Story = StoryObj<typeof ToggleButtonItem>;
+
+export const Selected: Story = {
+    args: {
+        isSelected: true,
+        option: "수면환경",
+    },
+};
+
+export const UnSelected: Story = {
+    args: {
+        isSelected: false,
+        option: "수면환경",
+    },
+};

--- a/src/shared/components/ToggleButtonGroup/ToggleButtonItem.stories.tsx
+++ b/src/shared/components/ToggleButtonGroup/ToggleButtonItem.stories.tsx
@@ -4,6 +4,11 @@ import type { Meta, StoryObj } from "@storybook/react";
 const meta: Meta<typeof ToggleButtonItem> = {
     title: "Components/Form/ToggleButtonItem",
     component: ToggleButtonItem,
+    argTypes: {
+        isSelected: {
+            control: "boolean",
+        },
+    },
 };
 
 export default meta;

--- a/src/shared/components/ToggleButtonGroup/ToggleButtonItem.tsx
+++ b/src/shared/components/ToggleButtonGroup/ToggleButtonItem.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+
+import { cn } from "@/shared/lib";
+import { Button } from "@/shared/ui";
+
+export interface ToggleButtonItemProps {
+    isSelected: boolean;
+
+    option: string;
+    setSelectedOption: React.Dispatch<React.SetStateAction<string>>;
+}
+
+export const ToggleButtonItem = ({
+    isSelected,
+    setSelectedOption,
+    option,
+}: ToggleButtonItemProps) => {
+    return (
+        <Button
+            className={cn(
+                isSelected ? "bg-primary text-white" : "bg-dark-100 text-dark-300",
+                "h-[34px]",
+            )}
+            onClick={() => setSelectedOption(option)}
+        >
+            {option}
+        </Button>
+    );
+};

--- a/src/shared/components/ToggleButtonGroup/ToggleButtonItem.tsx
+++ b/src/shared/components/ToggleButtonGroup/ToggleButtonItem.tsx
@@ -19,7 +19,7 @@ export const ToggleButtonItem = ({
         <Button
             className={cn(
                 isSelected ? "bg-primary text-white" : "bg-dark-100 text-dark-300",
-                "h-[34px]",
+                "h-[34px] flex-grow px-0",
             )}
             onClick={() => setSelectedOption(option)}
         >


### PR DESCRIPTION
## 🖇️ 연결 된 이슈

- resolve #70

## 🏞️ 첨부 파일

- `ToggleButtonGroup`, `ToggleButtonItem`
<img width="300" alt="image" src="https://github.com/user-attachments/assets/f6dc37d9-5e30-4c0c-bd3d-05c43fb719c2" />

- `ProfileDetailPage`
<img width="300" alt="image" src="https://github.com/user-attachments/assets/6370b87c-0449-40a9-8187-0caa975401ab" />


## 🆕 기능 추가

- `ToggleButtonGroup`, `ToggleButtonItem` 컴포넌트를 구현하였습니다
- `ProfileDetailPage` 를 구현하였습니다

## 📋 변경 사항

- `globals.css` 에 `bg-dark-100/50` 색상을 추가하였습니다

- `RangeDisplay` 컴포넌트의 상단 마진을 추가 하고 높이를 설정하였습니다
<img width="300" alt="image" src="https://github.com/user-attachments/assets/32115e75-499c-4a14-aa93-53c11a704b1a" />

- `ToggleButtonGroup` 컴포넌트의 `width` 프로퍼티 대신 `flex-grow` 속성을 사용해 부모에 맞게 설정되도록 스타일을 수정하였습니다.
