### PR TITLE
Design#82: NavTop 컴포넌트에 로고 아이콘 추가

### DIFF
--- a/src/apps/layouts/NavTop.stories.tsx
+++ b/src/apps/layouts/NavTop.stories.tsx
@@ -1,5 +1,3 @@
-import { Bell } from "lucide-react";
-
 import { NavTop } from "@/apps/layouts/NavTop";
 
 import type { Meta, StoryObj } from "@storybook/react";
@@ -13,7 +11,5 @@ export default meta;
 type Story = StoryObj<typeof NavTop>;
 
 export const Default: Story = {
-    args: {
-        children: <Bell size={24} />,
-    },
+    args: {},
 };

--- a/src/apps/layouts/NavTop.tsx
+++ b/src/apps/layouts/NavTop.tsx
@@ -10,9 +10,15 @@ export const NavTop = ({ children }: NavTopProps) => {
     return (
         <nav className="z-50 bg-white sticky top-0 h-[60px] shadow-md flex flex-col justify-center px-4">
             <ul className="flex items-center justify-between">
-                <li className="flex items-center gap-2" onClick={() => replace("HomePage", {})}>
-                    <img src="/favicon.svg" alt="룸핏" />
-                    <h1 className="text-lg font-bold">룸핏</h1>
+                <li
+                    className="flex items-center gap-2 w-[140px] hover:cursor-pointer"
+                    onClick={() => replace("MatchListPage", {})}
+                >
+                    <img
+                        className="block h-[50%]"
+                        src="/icon/logo-horizontal-dark.png"
+                        alt="룸핏"
+                    />
                 </li>
 
                 <li>{children}</li>


### PR DESCRIPTION
## 🖇️ 연결 된 이슈

- resolve #82 

## 🏞️ 첨부 파일

<img width="400" alt="image" src="https://github.com/user-attachments/assets/64d42712-f7ce-4e2d-a0c7-376bc86ec54c" />

## 📋 변경 사항

- 공통 상단 네비게이션 바 컴포넌트 `NavTop` 컴포넌트에 로고를 추가하였습니다.