### PR TITLE
Feature#38: 핏글 상세조회 API 모킹함수 구현

### DIFF
--- a/src/__mocks__/browser.ts
+++ b/src/__mocks__/browser.ts
@@ -1,6 +1,8 @@
-import { authHandlers } from "@/__mocks__/auth";
+// import { authHandlers } from "@/__mocks__/auth";
+import { matchHandlers } from "@/__mocks__/match";
 import { setupWorker } from "msw/browser";
 
-const handlers = [...authHandlers];
+// const handlers = [...authHandlers];
+const handlers = [...matchHandlers];
 
 export const worker = setupWorker(...handlers);

--- a/src/__mocks__/fetchMatchDetail.ts
+++ b/src/__mocks__/fetchMatchDetail.ts
@@ -1,21 +1,24 @@
 export const fetchMatchDetail = (id: number) => {
     console.log(`[Mocks] fetchMatchDetail : ${id}`);
-
     return {
+        id,
         title: "조용하고 청결한 룸메이트 구해요",
-        description:
-            "조용하고 청결한 룸메이트를 구합니다. 학교 근처에 있으면 좋겠어요. MBTI 는 I 를 선호합니다.",
+        // description:
+        //     "조용하고 청결한 룸메이트를 구합니다. 학교 근처에 있으면 좋겠어요. MBTI 는 I 를 선호합니다.",
 
         currentQuota: 1,
         maxQuota: 4,
 
         dormitory: "첨성관",
-        author: "홍길동",
+        author: {
+            id: 1,
+            nickname: "홍길동",
+        },
         createdAt: "2024-12-31",
 
         participants: [
-            { userId: 1, name: "홍길동" },
-            { userId: 2, name: "김기태" },
+            { id: 1, nickname: "홍길동" },
+            { id: 2, nickname: "김기태" },
         ],
     };
 };

--- a/src/__mocks__/handlers.ts
+++ b/src/__mocks__/handlers.ts
@@ -1,9 +1,0 @@
-import { http, HttpResponse } from "msw";
-
-import dummy from "./dummy.json";
-
-export const handlers = [
-    http.get("/dummy", () => {
-        return HttpResponse.json(dummy);
-    }),
-];

--- a/src/__mocks__/match/index.ts
+++ b/src/__mocks__/match/index.ts
@@ -1,0 +1,3 @@
+import { lookupDetailHandler } from "@/__mocks__/match/lookupDetail";
+
+export const matchHandlers = [...lookupDetailHandler()];

--- a/src/__mocks__/match/lookup.ts
+++ b/src/__mocks__/match/lookup.ts
@@ -1,0 +1,7 @@
+import { http, HttpResponse } from "msw";
+
+export const lookupHandler = () => {
+    http.get("url", () => {
+        return HttpResponse.json({});
+    });
+};

--- a/src/__mocks__/match/lookupDetail.ts
+++ b/src/__mocks__/match/lookupDetail.ts
@@ -1,0 +1,14 @@
+import { http, HttpResponse } from "msw";
+
+import { fetchMatchDetail } from "@/__mocks__/fetchMatchDetail";
+
+export const lookupDetailHandler = () => {
+    return [
+        http.get(`/api/v1/chat/:chatroom_id/participants`, async (id) => {
+            const { chatroom_id } = id.params;
+            const response = fetchMatchDetail(Number(chatroom_id));
+            console.log(response);
+            return HttpResponse.json([response]);
+        }),
+    ];
+};

--- a/src/features/match/service/lookupDetail.ts
+++ b/src/features/match/service/lookupDetail.ts
@@ -1,0 +1,16 @@
+export type LookUpDetailResponse = {
+    id: number;
+    title: string;
+    dormitory: string;
+    currentQuota: number;
+    maxQuota: number;
+    createdAt: string;
+    author: {
+        id: number;
+        nickname: string;
+    };
+    participants: Array<{
+        id: number;
+        nickname: string;
+    }>;
+};

--- a/src/features/match/ui/MatchInfo.tsx
+++ b/src/features/match/ui/MatchInfo.tsx
@@ -1,13 +1,17 @@
 import { House, Users } from "lucide-react";
 
 export interface MatchInfoProps {
+    id: number;
     title: string;
     dormitory: string;
 
     currentQuota: number;
     maxQuota: number;
 
-    author: string;
+    author: {
+        id: number;
+        nickname: string;
+    };
     createdAt: string;
 }
 
@@ -39,7 +43,7 @@ export const MatchInfo = ({
 
                 <ul className="flex gap-2 text-sm">
                     <li>
-                        <span>{author}</span>
+                        <span>{author.nickname}</span>
                     </li>
                     <li>
                         <span>{createdAt}</span>

--- a/src/pages/match/MatchDetailPage.tsx
+++ b/src/pages/match/MatchDetailPage.tsx
@@ -1,11 +1,14 @@
+import { useEffect, useState } from "react";
+
 import { BaseScreen } from "@/apps/Screen";
 
-import { fetchMatchDetail } from "@/__mocks__/fetchMatchDetail";
+// import { fetchMatchDetail } from "@/__mocks__/fetchMatchDetail";
 import { ChatProfileCard } from "@/entities/profile/ui/ChatProfileCard/ChatProfileCard";
-import { MatchInfo } from "@/features/match/ui/MatchInfo";
+import { MatchInfo, MatchInfoProps } from "@/features/match/ui/MatchInfo";
 import defaultImage from "@/shared/assets/bg-background.webp";
 import { BackDropImage } from "@/shared/components/BackDropImage";
 import { NavPrevious } from "@/shared/components/NavPrevious";
+import { api } from "@/shared/lib";
 import { ActivityComponentType } from "@stackflow/react";
 
 export interface MatchDetailPageParams {
@@ -13,20 +16,43 @@ export interface MatchDetailPageParams {
 }
 
 const MatchDetailPage: ActivityComponentType<MatchDetailPageParams> = ({ params }) => {
-    const mock__matchDetailResponse = fetchMatchDetail(params.id as number);
-
+    // const mock__matchDetailResponse = fetchMatchDetail(params.id as number);
+    const [data, setData] = useState<MatchInfoProps>({
+        id: 0,
+        title: "",
+        dormitory: "",
+        currentQuota: 0,
+        maxQuota: 0,
+        author: {
+            id: 0,
+            nickname: "",
+        },
+        createdAt: "",
+    });
+    useEffect(() => {
+        if (params.id) {
+            api.get(`/api/v1/chat/${params.id}/participants`)
+                .then((res) => {
+                    setData(res.data[0]);
+                })
+                .catch((error) => {
+                    console.error("API 호출 실패:", error);
+                });
+        }
+    }, [params.id]);
     return (
         <BaseScreen>
             <NavPrevious />
 
             <BackDropImage width="100%" height="220px" src={defaultImage}>
                 <MatchInfo
-                    title={mock__matchDetailResponse.title}
-                    dormitory={mock__matchDetailResponse.dormitory}
-                    currentQuota={mock__matchDetailResponse.currentQuota}
-                    maxQuota={mock__matchDetailResponse.maxQuota}
-                    author={mock__matchDetailResponse.author}
-                    createdAt={mock__matchDetailResponse.createdAt}
+                    title={data.title}
+                    dormitory={data.dormitory}
+                    currentQuota={data.currentQuota}
+                    maxQuota={data.maxQuota}
+                    author={data.author}
+                    createdAt={data.createdAt}
+                    id={data.id}
                 />
             </BackDropImage>
 


### PR DESCRIPTION
## 🖇️ 연결 된 이슈

- #38 

## 🏞️ 첨부 파일

![image](https://github.com/user-attachments/assets/c5908c9d-cac2-4343-9e00-2d69f961f9f7)

## 🆕 기능 추가

- **기능 추가**: 상세조회로 들어갔을 때 get에 대한 값을 받아오는지 모킹함수 추가했고, 정상적으로 받아오는 것을 확인했습니다.

## 📋 변경 사항

- MatchInfo와 MatchDetailPage의 일부 interface와 props가 수정되었습니다.
- #96 에 나온 스키마를 따라 변경하게 되었습니다.
