### PR TITLE
Feature#112: 프로필 등록시 최근 모집공고 Profile Form API 연동

### DIFF
--- a/data/recentSurvey.json
+++ b/data/recentSurvey.json
@@ -1,0 +1,255 @@
+{
+    "id": 1,
+    "title": "경북대학교 2025년 룸핏 모집공고",
+    "description": "경북대학교 2025년 룸핏 모집공고",
+    "questions": [
+        {
+            "id": 1,
+            "title": "기상시간",
+            "type": "doubleSlider",
+            "optionDelimiter": "시",
+            "options": [
+                { "label": "min", "value": "4" },
+                { "label": "max", "value": "12" }
+            ]
+        },
+        {
+            "id": 2,
+            "title": "취침시간",
+            "type": "doubleSlider",
+            "optionDelimiter": "시",
+            "options": [
+                { "label": "min", "value": "21" },
+                { "label": "max", "value": "27" }
+            ]
+        },
+        {
+            "id": 3,
+            "title": "잠귀",
+            "type": "slider",
+            "optionDelimiter": null,
+            "options": [
+                { "label": "어두움", "value": "1" },
+                { "label": "밝음", "value": "5" }
+            ]
+        },
+        {
+            "id": 4,
+            "title": "취침등",
+            "type": "selector",
+            "optionDelimiter": null,
+            "options": [
+                { "label": "없음", "value": "없음" },
+                { "label": "수면등", "value": "수면등" },
+                { "label": "스탠드", "value": "스탠드" }
+            ]
+        },
+        {
+            "id": 5,
+            "title": "알람 설정",
+            "type": "selector",
+            "optionDelimiter": null,
+            "options": [
+                { "label": "없음", "value": "없음" },
+                { "label": "10분마다", "value": "10분마다" },
+                { "label": "한번만", "value": "한번만" }
+            ]
+        },
+        {
+            "id": 6,
+            "title": "잠버릇",
+            "type": "checkbox",
+            "optionDelimiter": null,
+            "options": [
+                { "label": "이갈이", "value": "이갈이" },
+                { "label": "코골이", "value": "코골이" },
+                { "label": "잠꼬대", "value": "잠꼬대" },
+                { "label": "몸부림", "value": "몸부림" }
+            ]
+        },
+
+        {
+            "id": 7,
+            "title": "더위",
+            "type": "slider",
+            "optionDelimiter": null,
+            "options": [
+                { "label": "적게탐", "value": "1" },
+                { "label": "많이탐", "value": "5" }
+            ]
+        },
+        {
+            "id": 8,
+            "title": "추위",
+            "type": "slider",
+            "optionDelimiter": null,
+            "options": [
+                { "label": "적게탐", "value": "1" },
+                { "label": "많이탐", "value": "5" }
+            ]
+        },
+        {
+            "id": 9,
+            "title": "청소주기",
+            "type": "selector",
+            "optionDelimiter": null,
+            "options": [
+                { "label": "주1회", "value": "주1회" },
+                { "label": "주3~4회", "value": "주3~4회" },
+                { "label": "매일", "value": "매일" }
+            ]
+        },
+        {
+            "id": 10,
+            "title": "깨끗함",
+            "type": "slider",
+            "optionDelimiter": null,
+            "options": [
+                { "label": "더러움", "value": "1" },
+                { "label": "깨끗함", "value": "5" }
+            ]
+        },
+
+        {
+            "id": 11,
+            "title": "룸메이트와 관계",
+            "type": "slider",
+            "optionDelimiter": null,
+            "options": [
+                { "label": "학교사람", "value": "1" },
+                { "label": "절친", "value": "5" }
+            ]
+        },
+        {
+            "id": 12,
+            "title": "룸메이트와 물건공유",
+            "type": "selector",
+            "optionDelimiter": null,
+            "options": [
+                { "label": "없음", "value": "없음" },
+                { "label": "가능", "value": "가능" },
+                { "label": "협의", "value": "협의" }
+            ]
+        },
+        {
+            "id": 13,
+            "title": "친구초대",
+            "type": "selector",
+            "optionDelimiter": null,
+            "options": [
+                { "label": "상관없음", "value": "상관없음" },
+                { "label": "나도 아는 사람만", "value": "나도 아는 사람만" },
+                { "label": "싫음", "value": "싫음" },
+                { "label": "사전허락", "value": "사전허락" }
+            ]
+        },
+        {
+            "id": 16,
+            "title": "본가방문 주기",
+            "type": "selector",
+            "optionDelimiter": null,
+            "options": [
+                { "label": "방학만", "value": "방학만" },
+                { "label": "주말마다", "value": "주말마다" },
+                { "label": "2주에 한번", "value": "2주에 한번" },
+                { "label": "매달", "value": "매달" },
+                { "label": "한달 반", "value": "한달 반" }
+            ]
+        },
+        {
+            "id": 22,
+            "title": "벌레",
+            "type": "selector",
+            "optionDelimiter": null,
+            "options": [
+                { "label": "극혐", "value": "극혐" },
+                { "label": "못잡음", "value": "못잡음" },
+                { "label": "중간", "value": "중간" },
+                { "label": "잡음", "value": "잡음" },
+                { "label": "좋아함", "value": "좋아함" }
+            ]
+        },
+
+        {
+            "id": 14,
+            "title": "운동빈도",
+            "type": "selector",
+            "optionDelimiter": null,
+            "options": [
+                { "label": "안함", "value": "안함" },
+                { "label": "가끔함", "value": "가끔함" },
+                { "label": "매일함", "value": "매일함" }
+            ]
+        },
+        {
+            "id": 15,
+            "title": "운동시간대",
+            "type": "selector",
+            "optionDelimiter": null,
+            "options": [
+                { "label": "없음", "value": "없음" },
+                { "label": "아침", "value": "아침" },
+                { "label": "점심", "value": "점심" },
+                { "label": "저녁", "value": "저녁" }
+            ]
+        },
+
+        {
+            "id": 18,
+            "title": "게임",
+            "type": "selector",
+            "optionDelimiter": null,
+            "options": [
+                { "label": "안함", "value": "안함" },
+                { "label": "가끔", "value": "가끔" },
+                { "label": "매일", "value": "매일" }
+            ]
+        },
+        {
+            "id": 19,
+            "title": "흡연",
+            "type": "selector",
+            "optionDelimiter": null,
+            "options": [
+                { "label": "안함", "value": "없음" },
+                { "label": "전자담배", "value": "전자담배" },
+                { "label": "연초", "value": "연초" },
+                { "label": "둘다", "value": "둘다" }
+            ]
+        },
+        {
+            "id": 21,
+            "title": "음주빈도",
+            "type": "slider",
+            "optionDelimiter": null,
+            "options": [
+                { "label": "자주안마심", "value": "1" },
+                { "label": "자주마심", "value": "5" }
+            ]
+        },
+        {
+            "id": 17,
+            "title": "공부장소",
+            "type": "selector",
+            "optionDelimiter": null,
+            "options": [
+                { "label": "기숙사", "value": "기숙사" },
+                { "label": "도서관", "value": "도서관" },
+                { "label": "자습실", "value": "자습실" },
+                { "label": "유동적", "value": "유동적" }
+            ]
+        },
+        {
+            "id": 20,
+            "title": "실내통화",
+            "type": "selector",
+            "optionDelimiter": null,
+            "options": [
+                { "label": "안함", "value": "안함" },
+                { "label": "짧은통화", "value": "짧은통화" },
+                { "label": "자주함", "value": "자주함" },
+                { "label": "많이함", "value": "많이함" }
+            ]
+        }
+    ]
+}

--- a/src/__mocks__/profile/index.ts
+++ b/src/__mocks__/profile/index.ts
@@ -1,0 +1,3 @@
+import { readRecentSurveyHandler } from "@/__mocks__/profile/readRecentSurvey";
+
+export const profileHandlers = [...readRecentSurveyHandler];

--- a/src/__mocks__/profile/readRecentSurvey.ts
+++ b/src/__mocks__/profile/readRecentSurvey.ts
@@ -1,0 +1,263 @@
+import { http, HttpResponse } from "msw";
+
+export const readRecentSurveyHandler = [
+    http.get("/api/v1/survey", async () => {
+        return HttpResponse.json(recentSurvey);
+    }),
+];
+
+const recentSurvey = {
+    id: 1,
+    title: "경북대학교 2025년 룸핏 모집공고",
+    description: "경북대학교 2025년 룸핏 모집공고",
+    questions: [
+        {
+            id: 1,
+            title: "기상시간",
+            type: "doubleSlider",
+            optionDelimiter: "시",
+            options: [
+                { label: "min", value: "4" },
+                { label: "max", value: "12" },
+            ],
+        },
+        {
+            id: 2,
+            title: "취침시간",
+            type: "doubleSlider",
+            optionDelimiter: "시",
+            options: [
+                { label: "min", value: "21" },
+                { label: "max", value: "27" },
+            ],
+        },
+        {
+            id: 3,
+            title: "잠귀",
+            type: "slider",
+            optionDelimiter: null,
+            options: [
+                { label: "어두움", value: "1" },
+                { label: "밝음", value: "5" },
+            ],
+        },
+        {
+            id: 4,
+            title: "취침등",
+            type: "selector",
+            optionDelimiter: null,
+            options: [
+                { label: "없음", value: "없음" },
+                { label: "수면등", value: "수면등" },
+                { label: "스탠드", value: "스탠드" },
+            ],
+        },
+        {
+            id: 5,
+            title: "알람 설정",
+            type: "selector",
+            optionDelimiter: null,
+            options: [
+                { label: "없음", value: "없음" },
+                { label: "10분마다", value: "10분마다" },
+                { label: "한번만", value: "한번만" },
+            ],
+        },
+        {
+            id: 6,
+            title: "잠버릇",
+            type: "checkbox",
+            optionDelimiter: null,
+            options: [
+                { label: "이갈이", value: "이갈이" },
+                { label: "코골이", value: "코골이" },
+                { label: "잠꼬대", value: "잠꼬대" },
+                { label: "몸부림", value: "몸부림" },
+            ],
+        },
+
+        {
+            id: 7,
+            title: "더위",
+            type: "slider",
+            optionDelimiter: null,
+            options: [
+                { label: "적게탐", value: "1" },
+                { label: "많이탐", value: "5" },
+            ],
+        },
+        {
+            id: 8,
+            title: "추위",
+            type: "slider",
+            optionDelimiter: null,
+            options: [
+                { label: "적게탐", value: "1" },
+                { label: "많이탐", value: "5" },
+            ],
+        },
+        {
+            id: 9,
+            title: "청소주기",
+            type: "selector",
+            optionDelimiter: null,
+            options: [
+                { label: "주1회", value: "주1회" },
+                { label: "주3~4회", value: "주3~4회" },
+                { label: "매일", value: "매일" },
+            ],
+        },
+        {
+            id: 10,
+            title: "깨끗함",
+            type: "slider",
+            optionDelimiter: null,
+            options: [
+                { label: "더러움", value: "1" },
+                { label: "깨끗함", value: "5" },
+            ],
+        },
+
+        {
+            id: 11,
+            title: "룸메이트와 관계",
+            type: "slider",
+            optionDelimiter: null,
+            options: [
+                { label: "학교사람", value: "1" },
+                { label: "절친", value: "5" },
+            ],
+        },
+        {
+            id: 12,
+            title: "룸메이트와 물건공유",
+            type: "selector",
+            optionDelimiter: null,
+            options: [
+                { label: "없음", value: "없음" },
+                { label: "가능", value: "가능" },
+                { label: "협의", value: "협의" },
+            ],
+        },
+        {
+            id: 13,
+            title: "친구초대",
+            type: "selector",
+            optionDelimiter: null,
+            options: [
+                { label: "상관없음", value: "상관없음" },
+                { label: "나도 아는 사람만", value: "나도 아는 사람만" },
+                { label: "싫음", value: "싫음" },
+                { label: "사전허락", value: "사전허락" },
+            ],
+        },
+        {
+            id: 16,
+            title: "본가방문 주기",
+            type: "selector",
+            optionDelimiter: null,
+            options: [
+                { label: "방학만", value: "방학만" },
+                { label: "주말마다", value: "주말마다" },
+                { label: "2주에 한번", value: "2주에 한번" },
+                { label: "매달", value: "매달" },
+                { label: "한달 반", value: "한달 반" },
+            ],
+        },
+        {
+            id: 22,
+            title: "벌레",
+            type: "selector",
+            optionDelimiter: null,
+            options: [
+                { label: "극혐", value: "극혐" },
+                { label: "못잡음", value: "못잡음" },
+                { label: "중간", value: "중간" },
+                { label: "잡음", value: "잡음" },
+                { label: "좋아함", value: "좋아함" },
+            ],
+        },
+
+        {
+            id: 14,
+            title: "운동빈도",
+            type: "selector",
+            optionDelimiter: null,
+            options: [
+                { label: "안함", value: "안함" },
+                { label: "가끔함", value: "가끔함" },
+                { label: "매일함", value: "매일함" },
+            ],
+        },
+        {
+            id: 15,
+            title: "운동시간대",
+            type: "selector",
+            optionDelimiter: null,
+            options: [
+                { label: "없음", value: "없음" },
+                { label: "아침", value: "아침" },
+                { label: "점심", value: "점심" },
+                { label: "저녁", value: "저녁" },
+            ],
+        },
+
+        {
+            id: 18,
+            title: "게임",
+            type: "selector",
+            optionDelimiter: null,
+            options: [
+                { label: "안함", value: "안함" },
+                { label: "가끔", value: "가끔" },
+                { label: "매일", value: "매일" },
+            ],
+        },
+        {
+            id: 19,
+            title: "흡연",
+            type: "selector",
+            optionDelimiter: null,
+            options: [
+                { label: "안함", value: "없음" },
+                { label: "전자담배", value: "전자담배" },
+                { label: "연초", value: "연초" },
+                { label: "둘다", value: "둘다" },
+            ],
+        },
+        {
+            id: 21,
+            title: "음주빈도",
+            type: "slider",
+            optionDelimiter: null,
+            options: [
+                { label: "자주안마심", value: "1" },
+                { label: "자주마심", value: "5" },
+            ],
+        },
+        {
+            id: 17,
+            title: "공부장소",
+            type: "selector",
+            optionDelimiter: null,
+            options: [
+                { label: "기숙사", value: "기숙사" },
+                { label: "도서관", value: "도서관" },
+                { label: "자습실", value: "자습실" },
+                { label: "유동적", value: "유동적" },
+            ],
+        },
+        {
+            id: 20,
+            title: "실내통화",
+            type: "selector",
+            optionDelimiter: null,
+            options: [
+                { label: "안함", value: "안함" },
+                { label: "짧은통화", value: "짧은통화" },
+                { label: "자주함", value: "자주함" },
+                { label: "많이함", value: "많이함" },
+            ],
+        },
+    ],
+};

--- a/src/apps/stackflow.tsx
+++ b/src/apps/stackflow.tsx
@@ -8,6 +8,7 @@ import MatchDetailPage from "@/pages/match/MatchDetailPage";
 import MatchListPage from "@/pages/match/MatchListPage";
 import MyPage from "@/pages/mypage/MyPage";
 import ProfileDetailPage from "@/pages/profile/ProfileDetailPage";
+import ProfileEditPage from "@/pages/profile/ProfileEditPage";
 
 import { basicUIPlugin } from "@stackflow/plugin-basic-ui";
 import { historySyncPlugin } from "@stackflow/plugin-history-sync";
@@ -37,6 +38,7 @@ const stackflowApp = stackflow({
 
                 MyPage: "/mypage",
                 ProfileDetailPage: "/profile/detail",
+                ProfileEditPage: "/profile/edit",
             },
             fallbackActivity: () => "HomePage",
         }),
@@ -57,6 +59,7 @@ const stackflowApp = stackflow({
 
         MyPage,
         ProfileDetailPage,
+        ProfileEditPage,
     },
     initialActivity: () => "HomePage",
 });

--- a/src/entities/form/__tests__/FormFactory.test.tsx
+++ b/src/entities/form/__tests__/FormFactory.test.tsx
@@ -26,14 +26,14 @@ describe("FormFactory", () => {
             });
 
             test("questionType 이 selector 인 경우 SelectorFormElement 를 반환한다", () => {
-                formSchema.questions[0].type = "selector";
+                formSchema.questions[0].type = "SELECTOR";
 
                 const form = FormFactory.createFormBySchema(formSchema);
                 expect(form).toContain(SelectorFormElement);
             });
 
             test("questionType 이 checkbox 인 경우 CheckboxFormElement 를 반환한다", () => {
-                formSchema.questions[0].type = "checkbox";
+                formSchema.questions[0].type = "CHECKBOX";
 
                 const form = FormFactory.createFormBySchema(formSchema);
                 expect(form).toContain(CheckboxFormElement);

--- a/src/entities/form/config/formElementTypes.ts
+++ b/src/entities/form/config/formElementTypes.ts
@@ -6,8 +6,8 @@ import { SelectorFormElement } from "@/entities/form/ui/SelectorFormElement";
 export type FormElementType = keyof typeof formElementMap;
 
 export const formElementMap = {
-    selector: SelectorFormElement,
-    checkbox: CheckboxFormElement,
-    slider: SliderFormElement,
-    doubleSlider: DoubleSliderFormElement,
+    SELECTOR: SelectorFormElement,
+    CHECKBOX: CheckboxFormElement,
+    SLIDER: SliderFormElement,
+    DOUBLE_SLIDER: DoubleSliderFormElement,
 };

--- a/src/entities/form/types/index.d.ts
+++ b/src/entities/form/types/index.d.ts
@@ -54,7 +54,3 @@ export interface FormSchema {
     description: string;
     questions: Question[];
 }
-
-export interface ButtonProps extends React.ComponentProps<"button"> {
-    children: React.ReactNode;
-}

--- a/src/entities/form/ui/CheckBoxFormElement.stories.tsx
+++ b/src/entities/form/ui/CheckBoxFormElement.stories.tsx
@@ -19,7 +19,7 @@ const formInitialState: FormSchema = {
         {
             id: 1,
             title: "선호하는 색상이 무엇인가요?",
-            type: "checkbox",
+            type: "CHECKBOX",
             optionDelimiter: null,
             options: [
                 { label: "빨강", value: "Red" },

--- a/src/entities/form/ui/DoubleSliderFormElement.stories.tsx
+++ b/src/entities/form/ui/DoubleSliderFormElement.stories.tsx
@@ -19,7 +19,7 @@ const formInitialState: FormSchema = {
         {
             id: 1,
             title: "기상시간",
-            type: "doubleSlider",
+            type: "DOUBLE_SLIDER",
             options: [
                 { label: "최소", value: "4" },
                 { label: "최대", value: "12" },

--- a/src/entities/form/ui/DynamicForm.stories.tsx
+++ b/src/entities/form/ui/DynamicForm.stories.tsx
@@ -15,6 +15,7 @@ const formSchema: FormSchema = {
     title: "경북대학교 2025년 룸핏 모집공고",
     description: "경북대학교 2025년 룸핏 모집공고",
     questions: [
+        // 수면
         {
             id: 1,
             title: "기상시간",
@@ -79,6 +80,7 @@ const formSchema: FormSchema = {
                 { label: "몸부림", value: "몸부림" },
             ],
         },
+        // 환경 및 관계
         {
             id: 7,
             title: "더위",
@@ -112,6 +114,16 @@ const formSchema: FormSchema = {
         },
         {
             id: 10,
+            title: "깨끗함",
+            type: "slider",
+            optionDelimiter: null,
+            options: [
+                { label: "더러움", value: "1" },
+                { label: "깨끗함", value: "5" },
+            ],
+        },
+        {
+            id: 11,
             title: "룸메이트와 관계",
             type: "slider",
             optionDelimiter: null,
@@ -121,7 +133,7 @@ const formSchema: FormSchema = {
             ],
         },
         {
-            id: 11,
+            id: 12,
             title: "룸메이트와 물건공유",
             type: "selector",
             optionDelimiter: null,
@@ -132,18 +144,20 @@ const formSchema: FormSchema = {
             ],
         },
         {
-            id: 12,
+            id: 13,
             title: "친구초대",
             type: "selector",
             optionDelimiter: null,
             options: [
-                { label: "불가", value: "불가" },
-                { label: "가끔", value: "가끔" },
-                { label: "자주", value: "자주" },
+                { label: "상관없음", value: "상관없음" },
+                { label: "나도 아는 사람만", value: "나도 아는 사람만" },
+                { label: "싫음", value: "싫음" },
+                { label: "사전허락", value: "사전허락" },
             ],
         },
+        // 취미 및 생활
         {
-            id: 13,
+            id: 14,
             title: "운동빈도",
             type: "selector",
             optionDelimiter: null,
@@ -151,66 +165,47 @@ const formSchema: FormSchema = {
                 { label: "안함", value: "안함" },
                 { label: "가끔함", value: "가끔함" },
                 { label: "매일함", value: "매일함" },
-            ],
-        },
-        {
-            id: 14,
-            title: "운동시간대",
-            type: "selector",
-            optionDelimiter: null,
-            options: [
-                { label: "없음", value: "없음" },
-                { label: "아침", value: "아침" },
-                { label: "점심", value: "점심" },
-                { label: "저녁", value: "저녁" },
             ],
         },
         {
             id: 15,
-            title: "본가방문 주기",
-            type: "selector",
-            optionDelimiter: null,
-            options: [
-                { label: "없음", value: "없음" },
-                { label: "수면등", value: "수면등" },
-                { label: "스탠드", value: "스탠드" },
-            ],
-        },
-        {
-            id: 16,
-            title: "공부장소",
-            type: "selector",
-            optionDelimiter: null,
-            options: [
-                { label: "없음", value: "없음" },
-                { label: "수면등", value: "수면등" },
-                { label: "스탠드", value: "스탠드" },
-            ],
-        },
-        {
-            id: 17,
-            title: "운동빈도",
-            type: "selector",
-            optionDelimiter: null,
-            options: [
-                { label: "안함", value: "안함" },
-                { label: "가끔함", value: "가끔함" },
-                { label: "매일함", value: "매일함" },
-            ],
-        },
-        {
-            id: 18,
             title: "운동시간대",
             type: "selector",
             optionDelimiter: null,
             options: [
+                { label: "없음", value: "없음" },
                 { label: "아침", value: "아침" },
                 { label: "점심", value: "점심" },
                 { label: "저녁", value: "저녁" },
             ],
         },
         {
-            id: 19,
+            id: 16,
+            title: "본가방문 주기",
+            type: "selector",
+            optionDelimiter: null,
+            options: [
+                { label: "방학만", value: "방학만" },
+                { label: "주말마다", value: "주말마다" },
+                { label: "2주에 한번", value: "2주에 한번" },
+                { label: "매달", value: "매달" },
+                { label: "한달 반", value: "한달 반" },
+            ],
+        },
+        {
+            id: 17,
+            title: "공부장소",
+            type: "selector",
+            optionDelimiter: null,
+            options: [
+                { label: "기숙사", value: "기숙사" },
+                { label: "도서관", value: "도서관" },
+                { label: "자습실", value: "자습실" },
+                { label: "유동적", value: "유동적" },
+            ],
+        },
+        {
+            id: 18,
             title: "게임",
             type: "selector",
             optionDelimiter: null,
@@ -221,7 +216,7 @@ const formSchema: FormSchema = {
             ],
         },
         {
-            id: 20,
+            id: 19,
             title: "흡연",
             type: "selector",
             optionDelimiter: null,
@@ -233,7 +228,7 @@ const formSchema: FormSchema = {
             ],
         },
         {
-            id: 21,
+            id: 20,
             title: "실내통화",
             type: "selector",
             optionDelimiter: null,
@@ -241,16 +236,27 @@ const formSchema: FormSchema = {
                 { label: "안함", value: "안함" },
                 { label: "짧은통화", value: "짧은통화" },
                 { label: "자주함", value: "자주함" },
+                { label: "많이함", value: "많이함" },
             ],
         },
         {
-            id: 22,
+            id: 21,
             title: "음주빈도",
             type: "slider",
             optionDelimiter: null,
             options: [
                 { label: "자주안마심", value: "1" },
                 { label: "자주마심", value: "5" },
+            ],
+        },
+        {
+            id: 22,
+            title: "나는 대학 옮길 준비가 되어 있다",
+            type: "selector",
+            optionDelimiter: null,
+            options: [
+                { label: "예", value: "예" },
+                { label: "아니오", value: "아니오" },
             ],
         },
     ],

--- a/src/entities/form/ui/DynamicForm.tsx
+++ b/src/entities/form/ui/DynamicForm.tsx
@@ -8,10 +8,12 @@ export interface FormProps {
 export const DynamicForm = ({ formSchema }: FormProps) => {
     return (
         <FormStateContextProvider formInitialState={formSchema}>
-            {formSchema.questions.map((question) => {
-                const Component = formElementMap[question.type as FormElementType];
-                return <Component {...question} />;
-            })}
+            <div className="flex flex-col gap-3">
+                {formSchema.questions.map((question) => {
+                    const Component = formElementMap[question.type as FormElementType];
+                    return <Component {...question} />;
+                })}
+            </div>
         </FormStateContextProvider>
     );
 };

--- a/src/entities/form/ui/SelectorFormElement.stories.tsx
+++ b/src/entities/form/ui/SelectorFormElement.stories.tsx
@@ -19,7 +19,7 @@ const formInitialState: FormSchema = {
         {
             id: 1,
             title: "선호하는 색상이 무엇인가요?",
-            type: "selector",
+            type: "SELECTOR",
             options: [
                 { label: "빨강", value: "Red" },
                 { label: "초록", value: "Green" },

--- a/src/entities/form/ui/SliderFormElement.stories.tsx
+++ b/src/entities/form/ui/SliderFormElement.stories.tsx
@@ -19,7 +19,7 @@ const formInitialState: FormSchema = {
         {
             id: 1,
             title: "잠귀에 대한 민감도를 선택해주세요.",
-            type: "slider",
+            type: "SLIDER",
             options: [
                 { label: "밝음", value: "1" },
                 { label: "어두움", value: "10" },

--- a/src/features/mypage/ui/MenuItem.tsx
+++ b/src/features/mypage/ui/MenuItem.tsx
@@ -1,11 +1,13 @@
-export interface MenuItemProps {
+import React from "react";
+
+export interface MenuItemProps extends React.ComponentProps<"div"> {
     label: string;
     icon?: React.ReactNode;
 }
 
-export const MenuItem = ({ label, icon }: MenuItemProps) => {
+export const MenuItem = ({ label, icon, ...rest }: MenuItemProps) => {
     return (
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-2" {...rest}>
             <span>{icon}</span>
             <span className="font-semibold">{label}</span>
         </div>

--- a/src/features/profile/service/index.ts
+++ b/src/features/profile/service/index.ts
@@ -1,0 +1,5 @@
+import { readRecentSurvey } from "@/features/profile/service/readRecentSurvey";
+
+export const profileService = {
+    readRecentSurvey,
+};

--- a/src/features/profile/service/keys.ts
+++ b/src/features/profile/service/keys.ts
@@ -1,0 +1,3 @@
+export const PROFILE_QUERY_KEY_FACTORY = {
+    READ_RECENT_SURVEY: () => ["SURVEY"],
+};

--- a/src/features/profile/service/readRecentSurvey.ts
+++ b/src/features/profile/service/readRecentSurvey.ts
@@ -1,0 +1,17 @@
+import ExceptionHandler from "axios-exception-handler";
+
+import { FormSchema } from "@/entities/form/types";
+import { api } from "@/shared/lib";
+import { BaseResponse } from "@/shared/types/BaseResponse";
+
+export type ReadRecentSurveyResponseBody = FormSchema;
+
+export async function readRecentSurvey() {
+    try {
+        const { data: response } =
+            await api.get<BaseResponse<ReadRecentSurveyResponseBody>>("/api/v1/survey");
+        return response.data;
+    } catch (err) {
+        ExceptionHandler(err).handle();
+    }
+}

--- a/src/features/profile/service/useRecentSurvey.ts
+++ b/src/features/profile/service/useRecentSurvey.ts
@@ -1,0 +1,12 @@
+import { profileService } from "@/features/profile/service";
+import { PROFILE_QUERY_KEY_FACTORY } from "@/features/profile/service/keys";
+import { useQuery } from "@tanstack/react-query";
+
+export const useRecentSurvey = () => {
+    const query = useQuery({
+        queryKey: PROFILE_QUERY_KEY_FACTORY.READ_RECENT_SURVEY(),
+        queryFn: () => profileService.readRecentSurvey(),
+    });
+
+    return { ...query };
+};

--- a/src/pages/mypage/MyPage.tsx
+++ b/src/pages/mypage/MyPage.tsx
@@ -11,12 +11,15 @@ import {
 
 import { BaseScreen } from "@/apps/Screen";
 import { NavTop } from "@/apps/layouts/NavTop";
+import { useFlow } from "@/apps/stackflow";
 
 import { Menu } from "@/features/mypage/ui/Menu";
 import { MenuItem } from "@/features/mypage/ui/MenuItem";
 import { ProfileHeader } from "@/features/mypage/ui/ProfileHeader";
 
 export default function MyPage() {
+    const { push } = useFlow();
+
     return (
         <BaseScreen>
             <NavTop />
@@ -26,7 +29,11 @@ export default function MyPage() {
 
                 <Menu label="내 정보 관리">
                     <MenuItem label="비밀번호 변경하기" icon={<KeyRound size={20} />} />
-                    <MenuItem label="프로필 관리하기" icon={<UserRoundPen size={20} />} />
+                    <MenuItem
+                        label="프로필 수정하기"
+                        icon={<UserRoundPen size={20} />}
+                        onClick={() => push("ProfileEditPage", {})}
+                    />
                     <MenuItem label="로그아웃" icon={<LogOut size={20} />} />
                 </Menu>
 

--- a/src/pages/profile/ProfileEditPage.tsx
+++ b/src/pages/profile/ProfileEditPage.tsx
@@ -19,7 +19,7 @@ export default function ProfileEditPage() {
                 ) : (
                     <div>
                         <DynamicForm formSchema={data as FormSchema} />
-                        <Button className="w-full">저장하기</Button>
+                        <Button className="w-full my-2">등록하기</Button>
                     </div>
                 )}
             </div>

--- a/src/pages/profile/ProfileEditPage.tsx
+++ b/src/pages/profile/ProfileEditPage.tsx
@@ -1,0 +1,28 @@
+import { BaseScreen } from "@/apps/Screen";
+
+import { FormSchema } from "@/entities/form/types";
+import { DynamicForm } from "@/entities/form/ui/DynamicForm";
+import { useRecentSurvey } from "@/features/profile/service/useRecentSurvey";
+import { NavPrevious } from "@/shared/components";
+import { Button } from "@/shared/ui";
+
+export default function ProfileEditPage() {
+    const { isPending, data } = useRecentSurvey();
+
+    return (
+        <BaseScreen>
+            <NavPrevious />
+
+            <div className="p-4">
+                {isPending ? (
+                    <div>loading</div>
+                ) : (
+                    <div>
+                        <DynamicForm formSchema={data as FormSchema} />
+                        <Button className="w-full">저장하기</Button>
+                    </div>
+                )}
+            </div>
+        </BaseScreen>
+    );
+}

--- a/src/shared/types/BaseResponse.d.ts
+++ b/src/shared/types/BaseResponse.d.ts
@@ -1,0 +1,5 @@
+export type BaseResponse<T> = {
+    success: boolean;
+    message: string;
+    data: T;
+};


### PR DESCRIPTION
## 🖇️ 연결 된 이슈

- #64 
- #112 

## 🏞️ 첨부 파일

<img width="300" alt="image" src="https://github.com/user-attachments/assets/69f5458e-d56a-45a5-a1a9-f5532f2c4e5b" />


## 🆕 기능 추가

- 최신 모집공고 (설문지) 조회 (`GET` : `/api/v1/survey`) 에 대한 API 를 연동하였습니다
  - `readRecentSurvey` 비동기 함수를 통해 요청을 처리하였습니다
  - `profileService` 객체 리터럴을 통해 `src/features/service/index.ts` 진입점에서 모듈화를 진행하였습니다
  - `useRecentSurvey` 훅에서 `@tanstack/react-query` 를 통해 캐싱하였습니다

## 📋 변경 사항

- 최신 설문에 대한 예제 스키마를 `data/recentSurvey.json` 에 추가하였습니다

## 📝 추가 사항

- @KNU-K 현재 `SurveySchema` 에서 `options` 가 반대로 불러와지는 버그가 존재합니다
- Survey 설문답변 생성 (`/api/v1/survey/reply`) 에 대한 요청/응답 타입이 필요합니다
