### PR TITLE
Feature#120: `ProfileModal` 컴포넌트 구현

### DIFF
--- a/src/apps/App.tsx
+++ b/src/apps/App.tsx
@@ -2,28 +2,31 @@ import { Bounce, ToastContainer } from "react-toastify";
 
 import { Stack } from "./stackflow";
 import "./styles/tailwind.css";
+import { ModalContextProvider } from "@/shared/components/Modal/ModalContextProvider";
 import { queryClient } from "@/shared/lib";
 import { QueryClientProvider } from "@tanstack/react-query";
 
 export default function App() {
     return (
-        <QueryClientProvider client={queryClient}>
-            <ToastContainer
-                position="top-right"
-                autoClose={3000}
-                hideProgressBar={false}
-                newestOnTop={false}
-                closeOnClick={false}
-                rtl={false}
-                pauseOnFocusLoss
-                draggable
-                pauseOnHover
-                theme="light"
-                transition={Bounce}
-            />
-            <main className="w-full max-w-[500px] mx-auto h-screen border-[1px]">
-                <Stack />
-            </main>
-        </QueryClientProvider>
+        <ModalContextProvider>
+            <QueryClientProvider client={queryClient}>
+                <ToastContainer
+                    position="top-right"
+                    autoClose={3000}
+                    hideProgressBar={false}
+                    newestOnTop={false}
+                    closeOnClick={false}
+                    rtl={false}
+                    pauseOnFocusLoss
+                    draggable
+                    pauseOnHover
+                    theme="light"
+                    transition={Bounce}
+                />
+                <main className="w-full max-w-[500px] mx-auto h-screen border-[1px]">
+                    <Stack />
+                </main>
+            </QueryClientProvider>
+        </ModalContextProvider>
     );
 }

--- a/src/apps/layouts/NavBottom.tsx
+++ b/src/apps/layouts/NavBottom.tsx
@@ -1,28 +1,36 @@
+import { Fragment } from "react/jsx-runtime";
+
 import { navBottom } from "@/apps/constants/nav";
 import { ActivityName } from "@/apps/stackflow";
 import { useFlow } from "@/apps/stackflow";
+
+import { ProfileModal } from "@/entities/profile/ui/ProfileModal/ProfileModal";
 
 export const NavBottom = () => {
     const { replace } = useFlow();
 
     return (
-        <nav className="w-full max-w-[500px] h-[70px] sticky bottom-0 z-30 bg-white shadow-2xl shadow-black">
-            <ul className="flex justify-around w-full h-full gap-4 px-2 bg-white ">
-                {navBottom.map((item, index) => {
-                    return (
-                        <li
-                            key={index}
-                            className="flex items-center h-full"
-                            onClick={() => replace(item.activityName as ActivityName, {})}
-                        >
-                            <button className="flex flex-col items-center">
-                                <item.icon size={25} />
-                                <p className="text-sm">{item.label}</p>
-                            </button>
-                        </li>
-                    );
-                })}
-            </ul>
-        </nav>
+        <Fragment>
+            <ProfileModal />
+
+            <nav className="w-full max-w-[500px] h-[70px] sticky bottom-0 z-30 bg-white shadow-2xl shadow-black">
+                <ul className="flex justify-around w-full h-full gap-4 px-2 bg-white ">
+                    {navBottom.map((item, index) => {
+                        return (
+                            <li
+                                key={index}
+                                className="flex items-center h-full"
+                                onClick={() => replace(item.activityName as ActivityName, {})}
+                            >
+                                <button className="flex flex-col items-center">
+                                    <item.icon size={25} />
+                                    <p className="text-sm">{item.label}</p>
+                                </button>
+                            </li>
+                        );
+                    })}
+                </ul>
+            </nav>
+        </Fragment>
     );
 };

--- a/src/entities/profile/ui/ProfileModal/ProfileModal.stories.tsx
+++ b/src/entities/profile/ui/ProfileModal/ProfileModal.stories.tsx
@@ -1,0 +1,22 @@
+import { ProfileModal } from "@/entities/profile/ui/ProfileModal/ProfileModal";
+import { ModalContextProvider } from "@/shared/components/Modal/ModalContextProvider";
+import type { Meta, StoryObj } from "@storybook/react";
+
+const meta: Meta<typeof ProfileModal> = {
+    title: "Entity/Profile/ProfileModal",
+    component: ProfileModal,
+};
+
+export default meta;
+type Story = StoryObj<typeof ProfileModal>;
+
+export const Default: Story = {
+    args: {},
+    render: () => {
+        return (
+            <ModalContextProvider>
+                <ProfileModal />
+            </ModalContextProvider>
+        );
+    },
+};

--- a/src/entities/profile/ui/ProfileModal/ProfileModal.tsx
+++ b/src/entities/profile/ui/ProfileModal/ProfileModal.tsx
@@ -1,0 +1,21 @@
+import { Modal } from "@/shared/components";
+import { Button } from "@/shared/ui";
+
+export const ProfileModal = () => {
+    return (
+        <Modal.Root>
+            <Modal.Content className="w-full m-8">
+                <h1 className="text-lg font-semibold text-primary">
+                    아직 프로필을 등록하지 않으셨네요
+                </h1>
+                <div className="my-2">
+                    <p>프로필을 등록하면 룸핏의 모든 서비스를 이용할 수 있어요!</p>
+                </div>
+
+                <Button variant="default" className="w-full">
+                    프로필 등록하기
+                </Button>
+            </Modal.Content>
+        </Modal.Root>
+    );
+};

--- a/src/shared/components/Modal/Modal.tsx
+++ b/src/shared/components/Modal/Modal.tsx
@@ -1,8 +1,9 @@
-import { useEffect } from "react";
+import React, { useEffect } from "react";
 import { createPortal } from "react-dom";
 
 import { useModal } from "@/shared/components/Modal/useModal";
 import { useInitialStyle } from "@/shared/hooks";
+import { cn } from "@/shared/lib";
 
 export interface ModalProps {
     children?: React.ReactNode;
@@ -13,17 +14,17 @@ const Root = ({ children }: ModalProps) => {
     if (!isOpen) return null;
 
     return createPortal(
-        <Modal.Container>
+        <Modal.Wrapper>
             <Modal.Overlay />
-            <Modal.Content>{children}</Modal.Content>
-        </Modal.Container>,
+            <Modal.Container>{children}</Modal.Container>
+        </Modal.Wrapper>,
         document.body,
     );
 };
 
-const Container = ({ children }: { children?: React.ReactNode }) => {
+const Wrapper = ({ children }: { children?: React.ReactNode }) => {
     return (
-        <div className="fixed inset-0 w-screen h-screen z-[100] grid place-items-center">
+        <div className="container fixed top-0 left-0 w-screen h-screen z-[100] flex items-center justify-center">
             {children}
         </div>
     );
@@ -31,21 +32,37 @@ const Container = ({ children }: { children?: React.ReactNode }) => {
 
 const Overlay = () => {
     const { closeModal } = useModal();
+
+    const { ref } = useInitialStyle<HTMLDivElement>({
+        opacity: "0",
+        transition: "all 200ms ease-in-out",
+    });
+
+    useEffect(() => {
+        const element = ref.current;
+        if (!element) return;
+
+        element.style.opacity = "1";
+    }, [ref]);
+
     return (
         <div
+            ref={ref}
             className="fixed top-0 left-0 w-screen h-screen bg-black/70 z-[100]"
             onClick={() => closeModal()}
         />
     );
 };
 
-const Content = ({ children }: { children?: React.ReactNode }) => {
+const Container = ({ children }: { children?: React.ReactNode }) => {
     const { isOpen } = useModal();
 
     const { ref } = useInitialStyle<HTMLDivElement>({
         opacity: "0",
         transform: "scale(0.7)",
     });
+
+    const { closeModal } = useModal();
 
     useEffect(() => {
         const element = ref.current;
@@ -63,10 +80,29 @@ const Content = ({ children }: { children?: React.ReactNode }) => {
     return (
         <div
             ref={ref}
-            className="bg-white z-[200] fixed p-4 rounded-md"
-            style={{
-                transition: "opacity 0.3s, transform 0.3s",
+            className="modal-Container z-[200] p-4 relative inset-0 w-full h-full flex justify-center items-center"
+            style={{ transition: "opacity 0.3s, transform 0.3s" }}
+            onClick={() => closeModal()}
+        >
+            {children}
+        </div>
+    );
+};
+
+export interface ModalContentProps extends React.ComponentProps<"div"> {
+    children?: React.ReactNode;
+    onClick?: (...e: never[]) => unknown;
+}
+
+export const Content = ({ className, children, onClick, ...props }: ModalContentProps) => {
+    return (
+        <div
+            className={cn("p-4 bg-white rounded-md", className)}
+            onClick={(e) => {
+                e.stopPropagation();
+                onClick && onClick();
             }}
+            {...props}
         >
             {children}
         </div>
@@ -75,6 +111,7 @@ const Content = ({ children }: { children?: React.ReactNode }) => {
 
 export const Modal = {
     Root,
+    Wrapper,
     Container,
     Overlay,
     Content,


### PR DESCRIPTION
## 🖇️ 연결 된 이슈

- resolve #118

## 🏞️ 첨부 파일

<img width="300" alt="image" src="https://github.com/user-attachments/assets/a45a6a93-dedf-4503-8897-8a73d51857b2" />

## 🆕 기능 추가

- 프로필 등록 모달 컴포넌트 (`ProfileModal`) 컴포넌트를 구현하였습니다.

## 📋 변경 사항

- `Modal` 컴포넌트 `Content` 컴포넌트에 이벤트 전파를 방지하도록 수정하였습니다.
  - 이벤트 전파 (Event Propagation)
    - 여러 Nested (중첩된) 태그가 있을때, 최 하위 태그를 클릭하면 최하위 태그부터 최상위 태그의 이벤트까지 모두 동작하는 현상입니다.
    - 하위 태그에서 `Event.stopPropagation()` 를 호출하면 상위 태그로 이벤트가 전파되는 현상을 막습니다.

## 📝 추가 사항

- 추후, 전역상태에서 `isProfileRegistered` 상태를 저장하고, 사용자가 프로필을 등록하지 않은 경우에 한해서만 프로필 모달을 띄우도록 수정합니다.
