### PR TITLE
Feature#119: 회원가입 이메일 인증 타이머 구현

### DIFF
--- a/src/features/auth/hooks/useNavigateSignUpSection.ts
+++ b/src/features/auth/hooks/useNavigateSignUpSection.ts
@@ -1,14 +1,22 @@
+import { toast } from "react-toastify";
+
 import { useFlow } from "@/apps/stackflow";
+
+import { useSignUpStore } from "@/features/auth/store/useSignUpStore";
 
 export const useNavigateSignUpSection = () => {
     const { push } = useFlow();
+
+    const { email, password, authToken } = useSignUpStore();
 
     const toHomePage = () => {
         push("HomePage", {});
     };
 
     const toSignUpInfoSection = () => {
-        push("SignUpPage", { section: 2 });
+        if (!email || !authToken) toast.error("이메일 인증을 먼저 해주세요");
+        else if (!password) toast.error("비밀번호를 입력해주세요");
+        else push("SignUpPage", { section: 2 });
     };
 
     const toSignUpVerifySection = () => {

--- a/src/features/auth/hooks/useNavigateSignUpSection.ts
+++ b/src/features/auth/hooks/useNavigateSignUpSection.ts
@@ -7,14 +7,14 @@ import { useSignUpStore } from "@/features/auth/store/useSignUpStore";
 export const useNavigateSignUpSection = () => {
     const { push } = useFlow();
 
-    const { email, password, authToken } = useSignUpStore();
+    const { isEmailVerified, email, password, authToken } = useSignUpStore();
 
     const toHomePage = () => {
         push("HomePage", {});
     };
 
     const toSignUpInfoSection = () => {
-        if (!email || !authToken) toast.error("이메일 인증을 먼저 해주세요");
+        if (!isEmailVerified || !email || !authToken) toast.error("이메일 인증을 먼저 해주세요");
         else if (!password) toast.error("비밀번호를 입력해주세요");
         else push("SignUpPage", { section: 2 });
     };

--- a/src/features/auth/hooks/useTimer.ts
+++ b/src/features/auth/hooks/useTimer.ts
@@ -1,0 +1,27 @@
+import { useState } from "react";
+
+export const useTimer = (time: number) => {
+    const [seconds, setSeconds] = useState(time);
+
+    const startTimer = () => {
+        const timer = setInterval(() => {
+            setSeconds((prev) => {
+                if (prev <= 0) {
+                    clearInterval(timer);
+                    return 0;
+                }
+                return prev - 1;
+            });
+        }, 1000);
+
+        return () => clearInterval(timer);
+    };
+
+    const formatTime = () => {
+        const minutes = Math.floor(seconds / 60);
+        const remainingSeconds = seconds % 60;
+        return `${minutes}:${remainingSeconds < 10 ? "0" : ""}${remainingSeconds}`;
+    };
+
+    return { seconds: formatTime(), startTimer };
+};

--- a/src/features/auth/service/emailVerify.ts
+++ b/src/features/auth/service/emailVerify.ts
@@ -17,7 +17,7 @@ export async function verifyEmailVerificationCode(body: EmailVerifyRequestBody) 
     try {
         EmailVerifySchema.parse(body);
         const { data: response } = await api.post<BaseResponse<EmailVerifyResponseBody>>(
-            "/api/v1/auth/verify",
+            "/api/v1/auth/code/verify",
             body,
         );
         if (!response.data) throw new Error("인증 코드가 올바르지 않습니다.");

--- a/src/features/auth/service/useSendEmailVerificationCode.ts
+++ b/src/features/auth/service/useSendEmailVerificationCode.ts
@@ -1,14 +1,18 @@
 import { useRef, useState } from "react";
 import { toast } from "react-toastify";
 
+import { useTimer } from "@/features/auth/hooks/useTimer";
 import { sendEmailVerificationCode } from "@/features/auth/service/emailCode";
 import { SignUpStoreActionType, useSignUpStore } from "@/features/auth/store/useSignUpStore";
 import { renderToastFromDerivedError } from "@/shared/utils/renderToastFromDerivedError";
 
 export const useSendEmailVerificationCode = () => {
-    const [isVisible, setIsVisible] = useState<boolean>(false);
+    const [isVerificationCodeInputFieldVisible, setIsVerificationCodeInputFieldVisible] =
+        useState<boolean>(false);
     const emailRef = useRef<HTMLInputElement>(null);
     const { dispatch } = useSignUpStore();
+
+    const { seconds, startTimer } = useTimer(5 * 60);
 
     const onSendEmailVerificationCode = async () => {
         if (!emailRef.current?.value) return;
@@ -21,7 +25,9 @@ export const useSendEmailVerificationCode = () => {
                 error: renderToastFromDerivedError,
             })
             .then((data) => {
-                setIsVisible(true);
+                setIsVerificationCodeInputFieldVisible(true);
+                startTimer();
+
                 dispatch({
                     type: SignUpStoreActionType.SET_EMAIL,
                     payload: { email },
@@ -33,5 +39,5 @@ export const useSendEmailVerificationCode = () => {
             });
     };
 
-    return { isVisible, emailRef, onSendEmailVerificationCode };
+    return { isVerificationCodeInputFieldVisible, emailRef, onSendEmailVerificationCode, seconds };
 };

--- a/src/features/auth/store/useSignUpStore.ts
+++ b/src/features/auth/store/useSignUpStore.ts
@@ -3,9 +3,12 @@ import { create } from "zustand";
 import { SignUpRequestBody } from "@/features/auth/service/signUp";
 import { devtools, redux } from "zustand/middleware";
 
-export type SignUpStoreState = SignUpRequestBody;
+export type SignUpStoreState = SignUpRequestBody & {
+    isEmailVerified: boolean;
+};
 
 export enum SignUpStoreActionType {
+    VERIFY_EMAIL = "VERIFY_EMAIL",
     SET_EMAIL = "SET_EMAIL",
     SET_PASSWORD = "SET_PASSWORD",
     SET_AUTH_TOKEN = "SET_AUTH_TOKEN",
@@ -18,6 +21,7 @@ export enum SignUpStoreActionType {
 }
 
 export type SignUpStoreAction =
+    | { type: SignUpStoreActionType.VERIFY_EMAIL }
     | { type: SignUpStoreActionType.SET_EMAIL; payload: { email: string } }
     | { type: SignUpStoreActionType.SET_PASSWORD; payload: { password: string } }
     | { type: SignUpStoreActionType.SET_AUTH_TOKEN; payload: { authToken: string } }
@@ -29,6 +33,7 @@ export type SignUpStoreAction =
     | { type: SignUpStoreActionType.COMPLETE };
 
 const initialState: SignUpStoreState = {
+    isEmailVerified: false,
     email: "",
     password: "",
     authToken: "",
@@ -44,6 +49,8 @@ export const signUpStoreReducer = (
     action: SignUpStoreAction,
 ): SignUpStoreState => {
     switch (action.type) {
+        case SignUpStoreActionType.VERIFY_EMAIL:
+            return { ...state, isEmailVerified: true };
         case SignUpStoreActionType.SET_EMAIL:
             return { ...state, email: action.payload.email };
         case SignUpStoreActionType.SET_PASSWORD:

--- a/src/pages/auth/SignUpVerifySection.tsx
+++ b/src/pages/auth/SignUpVerifySection.tsx
@@ -17,7 +17,8 @@ export default function SignUpVerifySection() {
     const [passwordConfirm, setPasswordConfirm] = useState<string>("");
     const { password, dispatch } = useSignUpStore();
 
-    const { emailRef, onSendEmailVerificationCode, isVisible } = useSendEmailVerificationCode();
+    const { emailRef, onSendEmailVerificationCode, isVerificationCodeInputFieldVisible, seconds } =
+        useSendEmailVerificationCode();
     const { emailVerificationCodeRef, isVerified, verifyCode } = useEmailVerify();
 
     const { toHomePage, toSignUpInfoSection } = useNavigateSignUpSection();
@@ -44,15 +45,16 @@ export default function SignUpVerifySection() {
                                     ref={emailRef}
                                 />
                                 <Button
-                                    className="flex-grow-[1]"
+                                    className="flex-grow-[1] w-24"
                                     onClick={onSendEmailVerificationCode}
+                                    disabled={isVerificationCodeInputFieldVisible}
                                 >
-                                    인증하기
+                                    {!isVerificationCodeInputFieldVisible ? "인증하기" : seconds}
                                 </Button>
                             </div>
                         </div>
 
-                        {isVisible && (
+                        {isVerificationCodeInputFieldVisible && (
                             <div>
                                 <Label
                                     htmlFor="verification-code"
@@ -70,7 +72,7 @@ export default function SignUpVerifySection() {
                                         disabled={isVerified}
                                     />
                                     <Button
-                                        className="flex-grow-[1]"
+                                        className="flex-grow-[1] w-24"
                                         onClick={verifyCode}
                                         disabled={isVerified}
                                     >


### PR DESCRIPTION
## 🖇️ 연결 된 이슈

- resolve #119

## 🏞️ 첨부 파일

<img width="300" alt="image" src="https://github.com/user-attachments/assets/2de9c0f5-d072-4b9a-aa69-b59ab4e7eb45" />

<img width="300" alt="image" src="https://github.com/user-attachments/assets/f342cf2d-ea64-497d-afb2-5519a034f910" />



## 🆕 기능 추가

- 회원가입 이메일 인증 타이머를 구현하였습니다
  - `useTimer` 커스텀 훅을 통해, 타이머에 대한 동작을 추상화하였습니다
- 회원가입 다음 섹션 이동 전, 이메일/비밀번호 필수 입력필드를 입력하도록 검증하였습니다
  - 필수 입력필드 누락시, `toast.error` 로 에러 토스트 메시지를 출력하도록 구현하였습니다

## 📋 변경 사항

- 변경된 이메일 인증 API 엔드포인트를 적용하였습니다
  - 기존의 `/api/v1/auth/verify` 에서 `/api/v1/auth/code/verify` 로 수정하였습니다
- 이메일 인증버튼 클릭시 하단 인증코드 입력상태를 나타내는 변수명을 수정하였습니다
  - `isVisible` 에서 `isVerificationCodeInputFieldVisible` 라는 직관적인 네이밍으로 수정하였습니다
