### PR TITLE
Feature#131 핏글 상세정보 API 연동

### DIFF
--- a/src/__mocks__/browser.ts
+++ b/src/__mocks__/browser.ts
@@ -1,8 +1,6 @@
-// import { authHandlers } from "@/__mocks__/auth";
 import { matchHandlers } from "@/__mocks__/match";
 import { setupWorker } from "msw/browser";
 
-// const handlers = [...authHandlers];
 const handlers = [...matchHandlers];
 
 export const worker = setupWorker(...handlers);

--- a/src/__mocks__/fetchMatchDetail.ts
+++ b/src/__mocks__/fetchMatchDetail.ts
@@ -3,8 +3,6 @@ export const fetchMatchDetail = (id: number) => {
     return {
         id,
         title: "조용하고 청결한 룸메이트 구해요",
-        // description:
-        //     "조용하고 청결한 룸메이트를 구합니다. 학교 근처에 있으면 좋겠어요. MBTI 는 I 를 선호합니다.",
 
         currentQuota: 1,
         maxQuota: 4,

--- a/src/__mocks__/match/index.ts
+++ b/src/__mocks__/match/index.ts
@@ -1,9 +1,4 @@
-// import { lookupDetailHandler } from "@/__mocks__/match/lookupDetail";
 import { lookupListHandler } from "@/__mocks__/match/lookupList";
 import { writeRecruitmentHandler } from "@/__mocks__/match/writeRecruiment";
 
-export const matchHandlers = [
-    // ...lookupDetailHandler,
-    ...lookupListHandler,
-    ...writeRecruitmentHandler,
-];
+export const matchHandlers = [...lookupListHandler, ...writeRecruitmentHandler];

--- a/src/entities/chat/ui/ChatProfileCard/ChatProfileCard.stories.tsx
+++ b/src/entities/chat/ui/ChatProfileCard/ChatProfileCard.stories.tsx
@@ -12,8 +12,8 @@ type Story = StoryObj<typeof ChatProfileCard>;
 export const Default: Story = {
     args: {
         id: 1,
-        name: "김대건",
-        description: "경북대학교 컴퓨터학부",
+        nickname: "김대건",
+        college: "경북대학교 컴퓨터학부",
         className: "w-[350px]",
     },
 };

--- a/src/entities/chat/ui/ChatProfileCard/ChatProfileCard.tsx
+++ b/src/entities/chat/ui/ChatProfileCard/ChatProfileCard.tsx
@@ -8,18 +8,17 @@ import { cn } from "@/shared/lib";
 
 export interface ChatProfileCardProps {
     className?: string;
-
     id: number;
-    name: string;
-    description: string;
+    nickname: string;
+    college: string;
     onClick?: () => void;
 }
 
 export const ChatProfileCard = ({
     id,
     className,
-    name,
-    description,
+    nickname,
+    college,
     onClick,
 }: ChatProfileCardProps) => {
     const { push } = useFlow();
@@ -35,8 +34,8 @@ export const ChatProfileCard = ({
         >
             <div className="flex items-center justify-between w-full h-full py-1">
                 <div className="relative flex-grow-[1] z-10">
-                    <h1 className="my-1 text-xl font-bold text-black">{name}</h1>
-                    <p className="text-sm font-semibold text-dark-400">{description}</p>
+                    <h1 className="my-1 text-xl font-bold text-black">{nickname}</h1>
+                    <p className="text-sm font-semibold text-dark-400">{college}</p>
                 </div>
                 <div>
                     <Chip theme="gray" className="gap-0">

--- a/src/entities/chat/ui/ChatSideBar/ChatProfileSideBar.stories.tsx
+++ b/src/entities/chat/ui/ChatSideBar/ChatProfileSideBar.stories.tsx
@@ -14,9 +14,9 @@ export const Default: Story = {
     render: () => {
         return (
             <ChatSideBar>
-                <ChatProfileCard id={0} name={"김룸핏"} description={"경북대학교 컴퓨터학부"} />
-                <ChatProfileCard id={1} name={"김룸핏"} description={"경북대학교 컴퓨터학부"} />
-                <ChatProfileCard id={2} name={"김룸핏"} description={"경북대학교 컴퓨터학부"} />
+                <ChatProfileCard id={0} nickname={"김룸핏"} college={"경북대학교 컴퓨터학부"} />
+                <ChatProfileCard id={1} nickname={"김룸핏"} college={"경북대학교 컴퓨터학부"} />
+                <ChatProfileCard id={2} nickname={"김룸핏"} college={"경북대학교 컴퓨터학부"} />
             </ChatSideBar>
         );
     },

--- a/src/entities/chat/ui/ChatSideBar/ChatSideBarProfileGroup.stories.tsx
+++ b/src/entities/chat/ui/ChatSideBar/ChatSideBarProfileGroup.stories.tsx
@@ -15,9 +15,9 @@ export const Default: Story = {
     render: () => {
         return (
             <ChatSideBarProfileGroup>
-                <ChatProfileCard id={1} name="김룸핏" description="경북대학교 컴퓨터학부" />
-                <ChatProfileCard id={2} name="김룸핏" description="경북대학교 컴퓨터학부" />
-                <ChatProfileCard id={3} name="김룸핏" description="경북대학교 컴퓨터학부" />
+                <ChatProfileCard id={1} nickname="김룸핏" college="경북대학교 컴퓨터학부" />
+                <ChatProfileCard id={2} nickname="김룸핏" college="경북대학교 컴퓨터학부" />
+                <ChatProfileCard id={3} nickname="김룸핏" college="경북대학교 컴퓨터학부" />
             </ChatSideBarProfileGroup>
         );
     },

--- a/src/features/chat/hooks/useInfObserverFetch.ts
+++ b/src/features/chat/hooks/useInfObserverFetch.ts
@@ -13,7 +13,6 @@ type useInfObserverOptions = {
 };
 
 export const useInfObserverFetch = <
-    // D extends Record<string, unknown>[],
     C extends HTMLElement = HTMLElement,
     T extends HTMLElement = HTMLElement,
 >({

--- a/src/features/match/service/index.ts
+++ b/src/features/match/service/index.ts
@@ -1,3 +1,1 @@
 export * from "./keys";
-// export * from "./service";
-// export * from "./useMatchDetailById";

--- a/src/features/match/service/readMatchDetail.ts
+++ b/src/features/match/service/readMatchDetail.ts
@@ -29,13 +29,14 @@ const readMatchDetail = async (id: number) => {
 };
 
 export const useMatchDetail = (id: number) => {
-    const { data } = useQuery({
+    const { data: response } = useQuery({
         queryKey: MATCH_QUERY_KEY_FACTORY.READ_MATCH_DETAIL_BY_ID(id),
         queryFn: () => readMatchDetail(id),
         enabled: !!id,
     });
 
     return {
-        data,
+        data: response,
+        participants: response?.participants,
     };
 };

--- a/src/features/match/ui/MatchFilter/MatchFilter.tsx
+++ b/src/features/match/ui/MatchFilter/MatchFilter.tsx
@@ -22,7 +22,6 @@ import {
 
 export const MatchFilter = () => {
     const {
-        // recruitmentStatus,
         numOfAppliedFilters,
         minRecruitmentPeople,
         maxRecruitmentPeople,

--- a/src/features/match/ui/MatchInfo.tsx
+++ b/src/features/match/ui/MatchInfo.tsx
@@ -6,21 +6,9 @@ export interface MatchInfoProps {
     dormitory: string;
     currentQuota: number;
     maxQuota: number;
-    // author: {
-    //     id: number;
-    //     nickname: string;
-    // };
-    // createdAt: string;
 }
 
-export const MatchInfo = ({
-    name,
-    dormitory,
-    currentQuota,
-    maxQuota,
-    // author,
-    // createdAt,
-}: MatchInfoProps) => {
+export const MatchInfo = ({ name, dormitory, currentQuota, maxQuota }: MatchInfoProps) => {
     return (
         <div className="flex flex-col justify-end w-full h-full p-4 text-white">
             <h1 className="mb-1 text-2xl font-semibold">{name}</h1>
@@ -38,15 +26,6 @@ export const MatchInfo = ({
                         </span>
                     </li>
                 </ul>
-
-                {/* <ul className="flex gap-2 text-sm">
-                    <li>
-                        <span>{author.nickname}</span>
-                    </li>
-                    <li>
-                        <span>{createdAt}</span>
-                    </li>
-                </ul> */}
             </div>
         </div>
     );

--- a/src/pages/chat/ChatRoomPage.tsx
+++ b/src/pages/chat/ChatRoomPage.tsx
@@ -30,7 +30,6 @@ const ChatRoomPage: ActivityComponentType<ChatRoomPageParams> = ({ params }) => 
         roomId: params.roomId,
     });
     const { participants } = useMatchDetail(params.roomId);
-    console.log(participants);
 
     const [isOpen, setIsOpen] = useState(false);
     const { data, isPending, scrollContainerRef, targetRef, hasNext } = useInfObserverFetch<

--- a/src/pages/chat/ChatRoomPage.tsx
+++ b/src/pages/chat/ChatRoomPage.tsx
@@ -6,7 +6,6 @@ import { Vote } from "lucide-react";
 import { Screen } from "@/apps/Screen";
 
 import { ChatHistoryFallback } from "@/entities/chat/ui/ChatHistory/ChatHistoryFallback";
-// import { ChatHistoryFallback } from "@/entities/chat/ui/ChatHistory/ChatHistoryFallback";
 import { ChatHistoryGroup } from "@/entities/chat/ui/ChatHistory/ChatHistoryGroup";
 import { ChatHistoryItem } from "@/entities/chat/ui/ChatHistory/ChatHistoryItem";
 import { ChatHistoryTime } from "@/entities/chat/ui/ChatHistory/ChatHistoryTime";

--- a/src/pages/chat/ChatRoomPage.tsx
+++ b/src/pages/chat/ChatRoomPage.tsx
@@ -17,6 +17,7 @@ import { ChatSideBar } from "@/entities/chat/ui/ChatSideBar/ChatProfileSideBar";
 import { ChatHistoryContextProvider } from "@/features/chat/contexts/ChatHistoryContext";
 import { useChat } from "@/features/chat/hooks/useChat";
 import { useInfObserverFetch } from "@/features/chat/hooks/useInfObserverFetch";
+import { useMatchDetail } from "@/features/match/service/readMatchDetail";
 import { ChatGradientLayer } from "@/shared/components/GradientLayers/ChatGradientLayer";
 import { ActivityComponentType } from "@stackflow/react";
 
@@ -29,6 +30,9 @@ const ChatRoomPage: ActivityComponentType<ChatRoomPageParams> = ({ params }) => 
         userId: 10,
         roomId: params.roomId,
     });
+    const { participants } = useMatchDetail(params.roomId);
+    console.log(participants);
+
     const [isOpen, setIsOpen] = useState(false);
     const { data, isPending, scrollContainerRef, targetRef, hasNext } = useInfObserverFetch<
         HTMLUListElement,
@@ -45,12 +49,14 @@ const ChatRoomPage: ActivityComponentType<ChatRoomPageParams> = ({ params }) => 
                     <ChatNavTop title={"채팅방 이름"} currentQuota={2} maxQuota={4}>
                         <Vote className="block text-dark-300" strokeWidth={1.5} />
                         <ChatSideBar open={isOpen} onOpenChange={() => setIsOpen(!isOpen)}>
-                            <ChatProfileCard
-                                id={1}
-                                name={"김룸핏"}
-                                description={"경북대학교 컴퓨터학부"}
-                                onClick={() => setIsOpen((prev) => !prev)}
-                            />
+                            {participants?.map((participant) => (
+                                <ChatProfileCard
+                                    key={participant.id}
+                                    id={participant.id}
+                                    nickname={participant.nickname}
+                                    college={participant.college}
+                                />
+                            ))}
                         </ChatSideBar>
                     </ChatNavTop>
 

--- a/src/pages/match/MatchDetailPage.tsx
+++ b/src/pages/match/MatchDetailPage.tsx
@@ -14,6 +14,7 @@ export interface MatchDetailPageParams {
 
 const MatchDetailPage: ActivityComponentType<MatchDetailPageParams> = ({ params }) => {
     const { data } = useMatchDetail(params.id);
+    console.log(data);
     return (
         <BaseScreen>
             <NavPrevious />
@@ -31,9 +32,14 @@ const MatchDetailPage: ActivityComponentType<MatchDetailPageParams> = ({ params 
             </BackDropImage>
 
             <div className="flex flex-col gap-5 p-6">
-                <ChatProfileCard id={1} name={"김룸핏"} description="경북대학교 컴퓨터학부" />
-                <ChatProfileCard id={2} name={"김룸핏"} description="경북대학교 컴퓨터학부" />
-                <ChatProfileCard id={3} name={"김룸핏"} description="경북대학교 컴퓨터학부" />
+                {data?.participants.map((participant) => (
+                    <ChatProfileCard
+                        key={participant.id}
+                        id={participant.id}
+                        nickname={participant.nickname}
+                        college={participant.college}
+                    />
+                ))}
             </div>
         </BaseScreen>
     );

--- a/src/pages/match/MatchDetailPage.tsx
+++ b/src/pages/match/MatchDetailPage.tsx
@@ -25,8 +25,6 @@ const MatchDetailPage: ActivityComponentType<MatchDetailPageParams> = ({ params 
                     dormitory={data?.dormitory ?? ""}
                     currentQuota={data?.currentQuota ?? 0}
                     maxQuota={data?.maxQuota ?? 0}
-                    // author={data?.author ?? { id: 0, nickname: "" }}
-                    // createdAt={data?.createdAt ?? ""}
                     id={data?.id ?? 0}
                 />
             </BackDropImage>

--- a/src/shared/components/BackDropImage.tsx
+++ b/src/shared/components/BackDropImage.tsx
@@ -7,13 +7,7 @@ export interface BackDropImageProps extends React.ComponentProps<"img"> {
     children?: React.ReactNode;
 }
 
-export const BackDropImage = ({
-    width,
-    height,
-    children,
-    ...props
-    // direction = "col",
-}: BackDropImageProps) => {
+export const BackDropImage = ({ width, height, children, ...props }: BackDropImageProps) => {
     return (
         <div className="relative" style={{ width: width, height: height }}>
             <img


### PR DESCRIPTION
- 변경된 상세조회 API 연동
- 채팅방 참가자 목록 렌더링

## 🖇️ 연결 된 이슈

- #131 

## 🏞️ 첨부 파일
![image](https://github.com/user-attachments/assets/d521dd4a-4545-4a4e-82cc-40d59e3cf875)
![image](https://github.com/user-attachments/assets/a7152489-d1f5-40be-9feb-2b498ebc3509)


## 🆕 기능 추가

- **기능 추가**: 상세정보 API 연동
- **기능 추가**: 참가자 목록 렌더링

## 📋 변경 사항

- readMatchDetail.ts의 useMatchDetail의 return 을 2가지로 바꿨습니다.

