### PR TITLE
Feature#118: 프로필 등록, 수정 페이지 API 연동

### DIFF
--- a/data/recentSurvey.json
+++ b/data/recentSurvey.json
@@ -6,7 +6,7 @@
         {
             "id": 1,
             "title": "기상시간",
-            "type": "doubleSlider",
+            "type": "DOUBLE_SLIDER",
             "optionDelimiter": "시",
             "options": [
                 { "label": "min", "value": "4" },
@@ -16,7 +16,7 @@
         {
             "id": 2,
             "title": "취침시간",
-            "type": "doubleSlider",
+            "type": "DOUBLE_SLIDER",
             "optionDelimiter": "시",
             "options": [
                 { "label": "min", "value": "21" },
@@ -26,7 +26,7 @@
         {
             "id": 3,
             "title": "잠귀",
-            "type": "slider",
+            "type": "SLIDER",
             "optionDelimiter": null,
             "options": [
                 { "label": "어두움", "value": "1" },
@@ -36,7 +36,7 @@
         {
             "id": 4,
             "title": "취침등",
-            "type": "selector",
+            "type": "SELECTOR",
             "optionDelimiter": null,
             "options": [
                 { "label": "없음", "value": "없음" },
@@ -47,7 +47,7 @@
         {
             "id": 5,
             "title": "알람 설정",
-            "type": "selector",
+            "type": "SELECTOR",
             "optionDelimiter": null,
             "options": [
                 { "label": "없음", "value": "없음" },
@@ -58,7 +58,7 @@
         {
             "id": 6,
             "title": "잠버릇",
-            "type": "checkbox",
+            "type": "CHECKBOX",
             "optionDelimiter": null,
             "options": [
                 { "label": "이갈이", "value": "이갈이" },
@@ -71,7 +71,7 @@
         {
             "id": 7,
             "title": "더위",
-            "type": "slider",
+            "type": "SLIDER",
             "optionDelimiter": null,
             "options": [
                 { "label": "적게탐", "value": "1" },
@@ -81,7 +81,7 @@
         {
             "id": 8,
             "title": "추위",
-            "type": "slider",
+            "type": "SLIDER",
             "optionDelimiter": null,
             "options": [
                 { "label": "적게탐", "value": "1" },
@@ -91,7 +91,7 @@
         {
             "id": 9,
             "title": "청소주기",
-            "type": "selector",
+            "type": "SELECTOR",
             "optionDelimiter": null,
             "options": [
                 { "label": "주1회", "value": "주1회" },
@@ -102,7 +102,7 @@
         {
             "id": 10,
             "title": "깨끗함",
-            "type": "slider",
+            "type": "SLIDER",
             "optionDelimiter": null,
             "options": [
                 { "label": "더러움", "value": "1" },
@@ -113,7 +113,7 @@
         {
             "id": 11,
             "title": "룸메이트와 관계",
-            "type": "slider",
+            "type": "SLIDER",
             "optionDelimiter": null,
             "options": [
                 { "label": "학교사람", "value": "1" },
@@ -123,7 +123,7 @@
         {
             "id": 12,
             "title": "룸메이트와 물건공유",
-            "type": "selector",
+            "type": "SELECTOR",
             "optionDelimiter": null,
             "options": [
                 { "label": "없음", "value": "없음" },
@@ -134,7 +134,7 @@
         {
             "id": 13,
             "title": "친구초대",
-            "type": "selector",
+            "type": "SELECTOR",
             "optionDelimiter": null,
             "options": [
                 { "label": "상관없음", "value": "상관없음" },
@@ -146,7 +146,7 @@
         {
             "id": 16,
             "title": "본가방문 주기",
-            "type": "selector",
+            "type": "SELECTOR",
             "optionDelimiter": null,
             "options": [
                 { "label": "방학만", "value": "방학만" },
@@ -159,7 +159,7 @@
         {
             "id": 22,
             "title": "벌레",
-            "type": "selector",
+            "type": "SELECTOR",
             "optionDelimiter": null,
             "options": [
                 { "label": "극혐", "value": "극혐" },
@@ -173,7 +173,7 @@
         {
             "id": 14,
             "title": "운동빈도",
-            "type": "selector",
+            "type": "SELECTOR",
             "optionDelimiter": null,
             "options": [
                 { "label": "안함", "value": "안함" },
@@ -184,7 +184,7 @@
         {
             "id": 15,
             "title": "운동시간대",
-            "type": "selector",
+            "type": "SELECTOR",
             "optionDelimiter": null,
             "options": [
                 { "label": "없음", "value": "없음" },
@@ -197,7 +197,7 @@
         {
             "id": 18,
             "title": "게임",
-            "type": "selector",
+            "type": "SELECTOR",
             "optionDelimiter": null,
             "options": [
                 { "label": "안함", "value": "안함" },
@@ -208,7 +208,7 @@
         {
             "id": 19,
             "title": "흡연",
-            "type": "selector",
+            "type": "SELECTOR",
             "optionDelimiter": null,
             "options": [
                 { "label": "안함", "value": "없음" },
@@ -220,7 +220,7 @@
         {
             "id": 21,
             "title": "음주빈도",
-            "type": "slider",
+            "type": "SLIDER",
             "optionDelimiter": null,
             "options": [
                 { "label": "자주안마심", "value": "1" },
@@ -230,7 +230,7 @@
         {
             "id": 17,
             "title": "공부장소",
-            "type": "selector",
+            "type": "SELECTOR",
             "optionDelimiter": null,
             "options": [
                 { "label": "기숙사", "value": "기숙사" },
@@ -242,7 +242,7 @@
         {
             "id": 20,
             "title": "실내통화",
-            "type": "selector",
+            "type": "SELECTOR",
             "optionDelimiter": null,
             "options": [
                 { "label": "안함", "value": "안함" },

--- a/src/entities/form/__tests__/FormFactory.test.tsx
+++ b/src/entities/form/__tests__/FormFactory.test.tsx
@@ -26,14 +26,14 @@ describe("FormFactory", () => {
             });
 
             test("questionType 이 selector 인 경우 SelectorFormElement 를 반환한다", () => {
-                formSchema.questions[0].type = "selector";
+                formSchema.questions[0].type = "SELECTOR";
 
                 const form = FormFactory.createFormBySchema(formSchema);
                 expect(form).toContain(SelectorFormElement);
             });
 
             test("questionType 이 checkbox 인 경우 CheckboxFormElement 를 반환한다", () => {
-                formSchema.questions[0].type = "checkbox";
+                formSchema.questions[0].type = "CHECKBOX";
 
                 const form = FormFactory.createFormBySchema(formSchema);
                 expect(form).toContain(CheckboxFormElement);

--- a/src/entities/form/config/formElementTypes.ts
+++ b/src/entities/form/config/formElementTypes.ts
@@ -6,8 +6,8 @@ import { SelectorFormElement } from "@/entities/form/ui/SelectorFormElement";
 export type FormElementType = keyof typeof formElementMap;
 
 export const formElementMap = {
-    selector: SelectorFormElement,
-    checkbox: CheckboxFormElement,
-    slider: SliderFormElement,
-    doubleSlider: DoubleSliderFormElement,
+    SELECTOR: SelectorFormElement,
+    CHECKBOX: CheckboxFormElement,
+    SLIDER: SliderFormElement,
+    DOUBLE_SLIDER: DoubleSliderFormElement,
 };

--- a/src/entities/form/contexts/FormStateContextProvider.tsx
+++ b/src/entities/form/contexts/FormStateContextProvider.tsx
@@ -1,32 +1,36 @@
-import { useLayoutEffect, useReducer } from "react";
+import { forwardRef, useImperativeHandle, useLayoutEffect, useReducer } from "react";
 
 import { FormStateContext } from "@/entities/form/contexts";
 import { FORM_DISPATCH_ACTION_TYPES, formReducer } from "@/entities/form/hooks/useFormStateContext";
 import { FormSchema } from "@/entities/form/types";
+import { DynamicFormRef } from "@/entities/form/ui/DynamicForm";
 
 export interface FormStateContextProviderProps {
     formInitialState: FormSchema;
     children?: React.ReactNode;
 }
 
-export const FormStateContextProvider = ({
-    formInitialState,
-    children,
-}: FormStateContextProviderProps) => {
-    const [formState, dispatch] = useReducer<typeof formReducer>(formReducer, formInitialState);
+export const FormStateContextProvider = forwardRef<DynamicFormRef, FormStateContextProviderProps>(
+    ({ formInitialState, children }, ref) => {
+        const [formState, dispatch] = useReducer<typeof formReducer>(formReducer, formInitialState);
 
-    useLayoutEffect(
-        () => dispatch({ type: FORM_DISPATCH_ACTION_TYPES.INITIALIZE_FORM_STATUS }),
-        [],
-    );
-    return (
-        <FormStateContext.Provider
-            value={{
-                formState,
-                dispatch,
-            }}
-        >
-            {children}
-        </FormStateContext.Provider>
-    );
-};
+        useImperativeHandle(ref, () => {
+            return { getFormState: () => formState };
+        });
+
+        useLayoutEffect(
+            () => dispatch({ type: FORM_DISPATCH_ACTION_TYPES.INITIALIZE_FORM_STATUS }),
+            [],
+        );
+        return (
+            <FormStateContext.Provider
+                value={{
+                    formState,
+                    dispatch,
+                }}
+            >
+                {children}
+            </FormStateContext.Provider>
+        );
+    },
+);

--- a/src/entities/form/ui/DynamicForm.stories.tsx
+++ b/src/entities/form/ui/DynamicForm.stories.tsx
@@ -19,7 +19,7 @@ const formSchema: FormSchema = {
         {
             id: 1,
             title: "기상시간",
-            type: "doubleSlider",
+            type: "DOUBLE_SLIDER",
             optionDelimiter: "시",
             options: [
                 { label: "min", value: "4" },
@@ -29,7 +29,7 @@ const formSchema: FormSchema = {
         {
             id: 2,
             title: "취침시간",
-            type: "doubleSlider",
+            type: "DOUBLE_SLIDER",
             optionDelimiter: "시",
             options: [
                 { label: "min", value: "21" },
@@ -39,7 +39,7 @@ const formSchema: FormSchema = {
         {
             id: 3,
             title: "잠귀",
-            type: "slider",
+            type: "SLIDER",
             optionDelimiter: null,
             options: [
                 { label: "어두움", value: "1" },
@@ -49,7 +49,7 @@ const formSchema: FormSchema = {
         {
             id: 4,
             title: "취침등",
-            type: "selector",
+            type: "SELECTOR",
             optionDelimiter: null,
             options: [
                 { label: "없음", value: "없음" },
@@ -60,7 +60,7 @@ const formSchema: FormSchema = {
         {
             id: 5,
             title: "알람 설정",
-            type: "selector",
+            type: "SELECTOR",
             optionDelimiter: null,
             options: [
                 { label: "없음", value: "없음" },
@@ -71,7 +71,7 @@ const formSchema: FormSchema = {
         {
             id: 6,
             title: "잠버릇",
-            type: "checkbox",
+            type: "CHECKBOX",
             optionDelimiter: null,
             options: [
                 { label: "이갈이", value: "이갈이" },
@@ -84,7 +84,7 @@ const formSchema: FormSchema = {
         {
             id: 7,
             title: "더위",
-            type: "slider",
+            type: "SLIDER",
             optionDelimiter: null,
             options: [
                 { label: "적게탐", value: "1" },
@@ -94,7 +94,7 @@ const formSchema: FormSchema = {
         {
             id: 8,
             title: "추위",
-            type: "slider",
+            type: "SLIDER",
             optionDelimiter: null,
             options: [
                 { label: "적게탐", value: "1" },
@@ -104,7 +104,7 @@ const formSchema: FormSchema = {
         {
             id: 9,
             title: "청소주기",
-            type: "selector",
+            type: "SELECTOR",
             optionDelimiter: null,
             options: [
                 { label: "주1회", value: "주1회" },
@@ -115,7 +115,7 @@ const formSchema: FormSchema = {
         {
             id: 10,
             title: "깨끗함",
-            type: "slider",
+            type: "SLIDER",
             optionDelimiter: null,
             options: [
                 { label: "더러움", value: "1" },
@@ -125,7 +125,7 @@ const formSchema: FormSchema = {
         {
             id: 11,
             title: "룸메이트와 관계",
-            type: "slider",
+            type: "SLIDER",
             optionDelimiter: null,
             options: [
                 { label: "학교사람", value: "1" },
@@ -135,7 +135,7 @@ const formSchema: FormSchema = {
         {
             id: 12,
             title: "룸메이트와 물건공유",
-            type: "selector",
+            type: "SELECTOR",
             optionDelimiter: null,
             options: [
                 { label: "없음", value: "없음" },
@@ -146,7 +146,7 @@ const formSchema: FormSchema = {
         {
             id: 13,
             title: "친구초대",
-            type: "selector",
+            type: "SELECTOR",
             optionDelimiter: null,
             options: [
                 { label: "상관없음", value: "상관없음" },
@@ -159,7 +159,7 @@ const formSchema: FormSchema = {
         {
             id: 14,
             title: "운동빈도",
-            type: "selector",
+            type: "SELECTOR",
             optionDelimiter: null,
             options: [
                 { label: "안함", value: "안함" },
@@ -170,7 +170,7 @@ const formSchema: FormSchema = {
         {
             id: 15,
             title: "운동시간대",
-            type: "selector",
+            type: "SELECTOR",
             optionDelimiter: null,
             options: [
                 { label: "없음", value: "없음" },
@@ -182,7 +182,7 @@ const formSchema: FormSchema = {
         {
             id: 16,
             title: "본가방문 주기",
-            type: "selector",
+            type: "SELECTOR",
             optionDelimiter: null,
             options: [
                 { label: "방학만", value: "방학만" },
@@ -195,7 +195,7 @@ const formSchema: FormSchema = {
         {
             id: 17,
             title: "공부장소",
-            type: "selector",
+            type: "SELECTOR",
             optionDelimiter: null,
             options: [
                 { label: "기숙사", value: "기숙사" },
@@ -207,7 +207,7 @@ const formSchema: FormSchema = {
         {
             id: 18,
             title: "게임",
-            type: "selector",
+            type: "SELECTOR",
             optionDelimiter: null,
             options: [
                 { label: "안함", value: "안함" },
@@ -218,7 +218,7 @@ const formSchema: FormSchema = {
         {
             id: 19,
             title: "흡연",
-            type: "selector",
+            type: "SELECTOR",
             optionDelimiter: null,
             options: [
                 { label: "안함", value: "없음" },
@@ -230,7 +230,7 @@ const formSchema: FormSchema = {
         {
             id: 20,
             title: "실내통화",
-            type: "selector",
+            type: "SELECTOR",
             optionDelimiter: null,
             options: [
                 { label: "안함", value: "안함" },
@@ -242,7 +242,7 @@ const formSchema: FormSchema = {
         {
             id: 21,
             title: "음주빈도",
-            type: "slider",
+            type: "SLIDER",
             optionDelimiter: null,
             options: [
                 { label: "자주안마심", value: "1" },
@@ -252,7 +252,7 @@ const formSchema: FormSchema = {
         {
             id: 22,
             title: "나는 대학 옮길 준비가 되어 있다",
-            type: "selector",
+            type: "SELECTOR",
             optionDelimiter: null,
             options: [
                 { label: "예", value: "예" },

--- a/src/entities/form/ui/DynamicForm.tsx
+++ b/src/entities/form/ui/DynamicForm.tsx
@@ -1,3 +1,5 @@
+import { forwardRef } from "react";
+
 import { formElementMap, FormElementType } from "@/entities/form/config";
 import { FormStateContextProvider } from "@/entities/form/contexts";
 import { FormSchema } from "@/entities/form/types";
@@ -5,9 +7,14 @@ import { FormSchema } from "@/entities/form/types";
 export interface FormProps {
     formSchema: FormSchema;
 }
-export const DynamicForm = ({ formSchema }: FormProps) => {
+
+export interface DynamicFormRef {
+    getFormState: () => FormSchema;
+}
+
+export const DynamicForm = forwardRef<DynamicFormRef, FormProps>(({ formSchema }, ref) => {
     return (
-        <FormStateContextProvider formInitialState={formSchema}>
+        <FormStateContextProvider formInitialState={formSchema} ref={ref}>
             <div className="flex flex-col gap-3">
                 {formSchema.questions.map((question) => {
                     const Component = formElementMap[question.type as FormElementType];
@@ -16,4 +23,4 @@ export const DynamicForm = ({ formSchema }: FormProps) => {
             </div>
         </FormStateContextProvider>
     );
-};
+});

--- a/src/features/profile/service/createSurveyResponse.ts
+++ b/src/features/profile/service/createSurveyResponse.ts
@@ -1,0 +1,46 @@
+import ExceptionHandler from "axios-exception-handler";
+
+import { FormSchema, Option } from "@/entities/form/types";
+import { api } from "@/shared/lib";
+import { BaseResponse } from "@/shared/types/BaseResponse";
+
+export type CreateSurveyRequestBody = {
+    questionReplies: {
+        questionId: number;
+        replies: Option[];
+    }[];
+};
+
+export type CreateSurveyResponseBody = {
+    id: number;
+    title: string;
+    description: string;
+    questions: {
+        id: number;
+        title: string;
+        type: string;
+        optionDelimiter: string | null;
+        options: Option[];
+    }[];
+};
+
+export async function createSurveyResponse(formSchema: FormSchema) {
+    const questionReplies = formSchema.questions.map((question) => {
+        return { questionId: question.id, replies: question.options };
+    });
+
+    const body: CreateSurveyRequestBody = { questionReplies };
+
+    try {
+        const { data: response } = await api.post<BaseResponse<CreateSurveyResponseBody>>(
+            "/api/v1/survey/reply",
+            body,
+        );
+        return response.data;
+    } catch (err) {
+        ExceptionHandler(err)
+            .addCase(500, "서버 오류가 발생했습니다.")
+            .addDefaultCase("설문조사 응답 생성에 실패했습니다.")
+            .handle();
+    }
+}

--- a/src/features/profile/service/createSurveyResponse.ts
+++ b/src/features/profile/service/createSurveyResponse.ts
@@ -3,6 +3,7 @@ import ExceptionHandler from "axios-exception-handler";
 import { FormSchema, Option } from "@/entities/form/types";
 import { api } from "@/shared/lib";
 import { BaseResponse } from "@/shared/types/BaseResponse";
+import { useMutation } from "@tanstack/react-query";
 
 export type CreateSurveyRequestBody = {
     questionReplies: {
@@ -44,3 +45,12 @@ export async function createSurveyResponse(formSchema: FormSchema) {
             .handle();
     }
 }
+
+export const useCreateSurveyResponse = (body: FormSchema) => {
+    return useMutation({
+        mutationFn: () => createSurveyResponse(body),
+        onSuccess: () => {
+            // TODO: 요청 성공시 query invalidation
+        },
+    });
+};

--- a/src/features/profile/service/index.ts
+++ b/src/features/profile/service/index.ts
@@ -1,5 +1,7 @@
+import { createSurveyResponse } from "@/features/profile/service/createSurveyResponse";
 import { readRecentSurvey } from "@/features/profile/service/readRecentSurvey";
 
 export const profileService = {
     readRecentSurvey,
+    createSurveyResponse,
 };

--- a/src/pages/profile/ProfileEditPage.tsx
+++ b/src/pages/profile/ProfileEditPage.tsx
@@ -1,13 +1,21 @@
+import { useRef } from "react";
+
 import { BaseScreen } from "@/apps/Screen";
 
 import { FormSchema } from "@/entities/form/types";
-import { DynamicForm } from "@/entities/form/ui/DynamicForm";
+import { DynamicForm, DynamicFormRef } from "@/entities/form/ui/DynamicForm";
+import { useCreateSurveyResponse } from "@/features/profile/service/createSurveyResponse";
 import { useRecentSurvey } from "@/features/profile/service/useRecentSurvey";
 import { NavPrevious } from "@/shared/components";
 import { Button } from "@/shared/ui";
 
 export default function ProfileEditPage() {
     const { isPending, data } = useRecentSurvey();
+
+    const dynamicFormRef = useRef<DynamicFormRef>(null);
+    const { mutate } = useCreateSurveyResponse(
+        dynamicFormRef.current?.getFormState() as FormSchema,
+    );
 
     return (
         <BaseScreen>
@@ -18,8 +26,17 @@ export default function ProfileEditPage() {
                     <div>loading</div>
                 ) : (
                     <div>
-                        <DynamicForm formSchema={data as FormSchema} />
-                        <Button className="w-full my-2">등록하기</Button>
+                        <DynamicForm ref={dynamicFormRef} formSchema={data as FormSchema} />
+                        <Button
+                            className="w-full my-2"
+                            onClick={() => {
+                                // TODO: 추후 API 스키마 변경에 따른 수정 필요
+                                console.log(dynamicFormRef.current?.getFormState());
+                                mutate();
+                            }}
+                        >
+                            등록하기
+                        </Button>
                     </div>
                 )}
             </div>


### PR DESCRIPTION
## 🖇️ 연결 된 이슈

- resolve #118

## 🏞️ 첨부 파일

<img width="1000" alt="image" src="https://github.com/user-attachments/assets/1a587d23-2579-4911-bab7-2a496480094c" />

## 🆕 기능 추가

- 기존, 프로필 등록하기 버튼 클릭시 Context 를 사용하여 상태 자체를 페이지에 전달하는 코드를 `useImperativeHandle` 를 사용하여 상태를 전달하는것이 아닌, 버튼 클릭시 `ref` 로 전달하도록 구현하였습니다
  - 상태가 변경될 때 마다, `FormStateContextProvider` 를 consume 하는 페이지 컴포넌트를 모두 재렌더링하지 않고 `useImperativeHandle` 이 자식 컴포넌트에서 제공하는 `ref` 를 사용함으로써 재렌더링을 최소화 하였습니다.
- `@tanstack/react-query` 를 사용하여 API 호출하는 훅을 래핑한 `useCreateSurveyResponse` 훅을 구현하였습니다

## 📋 변경 사항

- 백엔드 스키마 변경에 따라 `questionType` 을 `UPPER_SNAKE_CASE` 로 변경하였습니다
  - 기존 `selector`, `doubleSlider`, `slider`  를 `SELECTOR`, `DOUBLE_SLIDER`, `SLIDER` 로 변경하였습니다
- `formSchema` 를 프로필 등록 API 요청 전, `/survey/reply` 에 해당하는 스키마로 변경하는 전처리 작업을 `createSurveyResponse` 에서 수행하도록 변경하였습니다.

## 📝 추가 사항

- `/survey/reply` API 가 수정되는대로 반영하겠습니다 @KNU-K 
