### PR TITLE
Fix#135: 이메일 인증시 `VERIFY_EMAIL` 상태 업데이트 로직 추가

### DIFF
--- a/src/features/auth/service/useEmailVerify.ts
+++ b/src/features/auth/service/useEmailVerify.ts
@@ -2,14 +2,14 @@ import { useRef, useState } from "react";
 import { toast } from "react-toastify";
 
 import { verifyEmailVerificationCode } from "@/features/auth/service/emailVerify";
-import { useSignUpStore } from "@/features/auth/store/useSignUpStore";
+import { SignUpStoreActionType, useSignUpStore } from "@/features/auth/store/useSignUpStore";
 import { renderToastFromDerivedError } from "@/shared/utils/renderToastFromDerivedError";
 
 export const useEmailVerify = () => {
     const [isVerified, setIsVerified] = useState(false);
 
     const emailVerificationCodeRef = useRef<HTMLInputElement>(null);
-    const { authToken } = useSignUpStore();
+    const { authToken, dispatch } = useSignUpStore();
 
     const verifyCode = async () => {
         const verificationCode = emailVerificationCodeRef.current?.value as string;
@@ -27,6 +27,7 @@ export const useEmailVerify = () => {
                 },
             )
             .then(() => {
+                dispatch({ type: SignUpStoreActionType.VERIFY_EMAIL });
                 setIsVerified(true);
             });
     };


### PR DESCRIPTION
## 🖇️ 연결 된 이슈

- resolve #135 

## 📋 변경 사항

- 기존, 회원가입시 이메일을 인증하였음에도 다음 섹션으로 넘어가지 않는 버그를 수정하였습니다
  - 이메일 인증시 `VERIFY_EMAIL` 상태 업데이트 로직 추가하였습니다.