### PR TITLE
Fix#150 : 프로필 찾기 페이지에서, 프로필을 등록하지 않은 사용자 선택시 빈 화면이 뜨는 현상 해결

### DIFF
--- a/src/features/profile/service/readSurveyReplyById.ts
+++ b/src/features/profile/service/readSurveyReplyById.ts
@@ -31,7 +31,8 @@ export async function readSurveyReplyById(userId: number) {
     } catch (err) {
         ExceptionHandler(err)
             .addCase(404, "존재하지 않는 프로필입니다")
-            .addCase(500, "서버 오류가 발생했습니다")
+            // TODO : 추후, 404 에러에 대한 처리로 변경 필요.
+            .addCase(500, "존재하지 않는 프로필입니다")
             .handle();
     }
 }
@@ -40,6 +41,8 @@ export function useSurveyReplyById(userId: number) {
     const query = useQuery({
         queryKey: PROFILE_QUERY_KEY_FACTORY.READ_SURVEY_REPLY_BY_ID(userId),
         queryFn: () => readSurveyReplyById(userId),
+        throwOnError: false,
+        retry: false,
     });
     return { ...query };
 }

--- a/src/features/profile/service/readSurveyReplyById.ts
+++ b/src/features/profile/service/readSurveyReplyById.ts
@@ -41,7 +41,6 @@ export function useSurveyReplyById(userId: number) {
     const query = useQuery({
         queryKey: PROFILE_QUERY_KEY_FACTORY.READ_SURVEY_REPLY_BY_ID(userId),
         queryFn: () => readSurveyReplyById(userId),
-        throwOnError: false,
         retry: false,
     });
     return { ...query };

--- a/src/pages/profile/ProfileDetailPage.tsx
+++ b/src/pages/profile/ProfileDetailPage.tsx
@@ -1,6 +1,8 @@
 import { useState } from "react";
+import { toast } from "react-toastify";
 
 import { BaseScreen } from "@/apps/Screen";
+import { useFlow } from "@/apps/stackflow";
 
 import { DynamicReply } from "@/entities/profile/ui/DynamicReply/DynamicReply";
 import { ProfileGroup } from "@/entities/profile/ui/ProfileGroup/ProfileGroup";
@@ -26,10 +28,17 @@ export interface ProfileDetailPageProps {
 
 export default function ProfileDetailPage({ params }: ProfileDetailPageProps) {
     const { data } = useUserDetailsById(params.id);
-    const { isPending, data: reply } = useSurveyReplyById(params.id);
+    const { isPending, data: reply, isError, error } = useSurveyReplyById(params.id);
 
     const [range, setRange] = useState<{ min: number; max: number }>({ min: 0, max: 6 });
 
+    const { pop } = useFlow();
+
+    if (isError) {
+        toast.error(error.message);
+        pop();
+        return null;
+    }
     if (isPending) return <div>loading...</div>;
 
     return (

--- a/src/shared/lib/query.ts
+++ b/src/shared/lib/query.ts
@@ -5,6 +5,7 @@ export const queryClient = new QueryClient({
         queries: {
             staleTime: 1000 * 60 * 5, // 5 minutes
             gcTime: 1000 * 60 * 30, // 30 minutes
+            throwOnError: false,
         },
     },
 });


### PR DESCRIPTION
## 🖇️ 연결 된 이슈

- resolve #150

## 📋 변경 사항

- 프로필 찾기 페이지에서, 프로필을 등록하지 않은 사용자 선택시 빈 화면이 뜨는 현상 해결하였습니다
  - `500` 에러에 대해 `ExceptionHandler` 에서 임시로 '존재하지 않는 프로필입니다' 에러 핸들링 코드를 변경하였습니다
  - `ProfileDetailPage` 에서 query 가 반환하는 `isError`, `error` 값을 체크하여 해당 페이지로 이동하지 않도록 구현하였습니다

- `@tanstack/react-query` 의 `throwOnError` 필드는 `TanStack Query의 throwOnError는 쿼리 실행 중 오류가 발생했을 때, 오류를 React Query 내부에서 처리할지 아니면 호출한 쪽으로 던질지를 결정하는 옵션` 입니다
  - default 를 false 로 설정하여, `queryFn` 에서 발생한 예외를 `isError`, `error` 로 기본적으로 처리하도록 수정하였습니다

| 상황 | `throwOnError` 값 | 결과 |
|------|------------------|------|
| UI에서 `error.message`를 직접 표시하고 싶음 | `false` (기본값) | `isError: true` 상태에서 `error.message` 사용 가능 |
| 오류 발생 시 즉시 throw하여 Error Boundary에서 처리하고 싶음 | `true` | 오류 발생 즉시 Error Boundary로 전달 (컴포넌트 크래시 가능) |
| 특정 조건에 따라 오류를 throw할지 결정하고 싶음 | 함수 `(error, query) => boolean` | 특정 에러만 throw 가능 |


## 📝 추가 사항

- 추후 `404` 에러로 변경시 `readSurveyReplyById` 예외처리 코드를 수정해야합니다 @KNU-K 
