### PR TITLE
Fix#144: 프로필 등록 모달이 제대로 열리지 않는 현상 수정

### DIFF
--- a/src/shared/components/Modal/Modal.tsx
+++ b/src/shared/components/Modal/Modal.tsx
@@ -1,8 +1,8 @@
-import React, { useEffect } from "react";
+import React from "react";
 import { createPortal } from "react-dom";
 
 import { useModal } from "@/shared/components/Modal/useModal";
-import { useInitialStyle } from "@/shared/hooks";
+import { useOnMountAnimation } from "@/shared/hooks/useOnMountAnimation";
 import { cn } from "@/shared/lib";
 
 export interface ModalProps {
@@ -33,17 +33,17 @@ const Wrapper = ({ children }: { children?: React.ReactNode }) => {
 const Overlay = () => {
     const { closeModal } = useModal();
 
-    const { ref } = useInitialStyle<HTMLDivElement>({
-        opacity: "0",
-        transition: "all 200ms ease-in-out",
+    const { ref } = useOnMountAnimation<HTMLDivElement>({
+        initialStyles: {
+            opacity: "0",
+        },
+        animationStyles: {
+            opacity: "1",
+        },
+        duration: 200,
+        delay: 0,
+        timingFunction: "ease-in-out",
     });
-
-    useEffect(() => {
-        const element = ref.current;
-        if (!element) return;
-
-        element.style.opacity = "1";
-    }, [ref]);
 
     return (
         <div
@@ -55,27 +55,21 @@ const Overlay = () => {
 };
 
 const Container = ({ children }: { children?: React.ReactNode }) => {
-    const { isOpen } = useModal();
-
-    const { ref } = useInitialStyle<HTMLDivElement>({
-        opacity: "0",
-        transform: "scale(0.7)",
-    });
-
     const { closeModal } = useModal();
 
-    useEffect(() => {
-        const element = ref.current;
-        if (!element) return;
-
-        if (isOpen) {
-            element.style.opacity = "1";
-            element.style.transform = "scale(1)";
-        } else {
-            element.style.opacity = "0";
-            element.style.transform = "scale(0.7)";
-        }
-    }, [isOpen, ref]);
+    const { ref } = useOnMountAnimation<HTMLDivElement>({
+        initialStyles: {
+            opacity: "0",
+            transform: "scale(0.7)",
+        },
+        animationStyles: {
+            opacity: "1",
+            transform: "scale(1)",
+        },
+        duration: 200,
+        delay: 0,
+        timingFunction: "ease-in-out",
+    });
 
     return (
         <div

--- a/src/shared/hooks/useOnMountAnimation.ts
+++ b/src/shared/hooks/useOnMountAnimation.ts
@@ -1,0 +1,52 @@
+import { useCallback, useEffect, useLayoutEffect, useRef } from "react";
+
+export interface UseOnMountAnimationOption {
+    initialStyles: React.CSSProperties;
+    animationStyles: React.CSSProperties;
+
+    duration: number;
+    delay: number;
+    timingFunction: string;
+}
+
+export const useOnMountAnimation = <Element extends HTMLElement = HTMLDivElement>({
+    initialStyles,
+    animationStyles,
+
+    duration = 200,
+    delay = 0,
+    timingFunction = "ease-in-out",
+}: UseOnMountAnimationOption) => {
+    const ref = useRef<Element>(null);
+    const requestAnimationFrameRef = useRef<ReturnType<typeof requestAnimationFrame>>();
+
+    const animation = useCallback(() => {
+        const element = ref.current;
+        if (!element) throw new Error("[useOnMountAnimation] element 가 존재하지 않습니다.");
+
+        element.style.transition = `all ${duration}ms ${timingFunction} ${delay}ms`;
+        for (const [key, value] of Object.entries(animationStyles)) {
+            element.style.setProperty(key, value);
+        }
+    }, [animationStyles, delay, duration, timingFunction]);
+
+    useLayoutEffect(() => {
+        const element = ref.current;
+        if (!element) return;
+
+        for (const [key, value] of Object.entries(initialStyles)) {
+            element.style.setProperty(key, value);
+        }
+    }, [initialStyles]);
+
+    useEffect(() => {
+        requestAnimationFrameRef.current = requestAnimationFrame(animation);
+
+        return () => {
+            if (requestAnimationFrameRef.current)
+                cancelAnimationFrame(requestAnimationFrameRef.current);
+        };
+    }, [animation]);
+
+    return { ref };
+};


### PR DESCRIPTION
## 🖇️ 연결 된 이슈

- resolve #144 

## 🆕 기능 추가

- `useOnMountAnimation` 커스텀 훅을 구현하였습니다
  - 초기 스타일(`initialStyles`), 애니메이션 스타일(`animationStyles`), transition 옵션을 파라미터로 받아 애니메이션이 적용될 `ref` 를 반환합니다

## 📝 추가 사항

- 기존에 `useInitialStyles` 훅에서 초기 스타일이 적용된 이후, 바로 `useEffect` 에서 스타일이 적용되기 때문에 애니메이션이 제대로 적용되지 않는 문제가 발생하였습니다 (`useEffect` 는 콜스택에 바로 푸시됩니다)
- `useOnMountAnimation` 훅을 사용해 `requestAnimaionFrame` 을 사용하여 콜스택에 바로 푸시되는것이 아닌,  브라우저의 렌더링 사이클에 맞춰 다음 애니메이션 프레임 전에 실행되도록 예약하도록 수정하였습니다
