### PR TITLE
Fix#160: 채팅 히스토리 무한 스크롤이 제대로 동작하지 않는 현상 해결

### DIFF
--- a/src/entities/chat/ui/ChatInput/ChatInput.tsx
+++ b/src/entities/chat/ui/ChatInput/ChatInput.tsx
@@ -6,8 +6,9 @@ import { Button, Input } from "@/shared/ui";
 
 interface ChatInputProps extends React.ComponentProps<"input"> {
     children?: React.ReactNode;
-    onSendButtonClick?: React.EventHandler<React.MouseEvent<HTMLButtonElement>>;
+    onSendButtonClick?: () => void;
 }
+
 export const ChatInput = forwardRef<HTMLInputElement, ChatInputProps>(
     ({ onSendButtonClick, ...props }, ref) => {
         return (
@@ -15,9 +16,21 @@ export const ChatInput = forwardRef<HTMLInputElement, ChatInputProps>(
                 <Input
                     ref={ref}
                     className="text-sm focus:outline-none focus-visible:outline-none focus-visible:border-0 h-9 rounded-xl bg-dark-100 focus-visible:ring-0 focus:ring-0 focus-visible:ring-offset-0"
+                    onKeyDown={(e) => {
+                        if (e.key === "Enter") {
+                            e.preventDefault();
+                            onSendButtonClick?.();
+                        }
+                    }}
                     {...props}
                 />
-                <Button className="p-0 h-9 rounded-xl aspect-square" onClick={onSendButtonClick}>
+                <Button
+                    className="p-0 h-9 rounded-xl aspect-square"
+                    onClick={(e) => {
+                        e.preventDefault();
+                        onSendButtonClick?.();
+                    }}
+                >
                     <Send strokeWidth={1.4} />
                 </Button>
             </div>

--- a/src/features/chat/hooks/useChat.ts
+++ b/src/features/chat/hooks/useChat.ts
@@ -59,8 +59,7 @@ export const useChat = ({ roomId, userId, nickname }: UseChatOptions) => {
         subscribeTopic(`${STOMP_TOPIC_PREFIX}/${roomId}`);
     }, [roomId, subscribeTopic]);
 
-    const onError = (err: string) => {
-        console.log("Error: ", err);
+    const onError = () => {
         setIsConnected(false);
     };
 
@@ -95,7 +94,7 @@ export const useChat = ({ roomId, userId, nickname }: UseChatOptions) => {
             },
             content: message,
         };
-        console.log("ROOMID", roomId, "SENDER", userId);
+
         stompClient.current.send(
             `${STOMP_DESTINATION_PREFIX}/${roomId}`,
             {},

--- a/src/features/chat/hooks/useInfObserverFetch.ts
+++ b/src/features/chat/hooks/useInfObserverFetch.ts
@@ -28,6 +28,7 @@ export const useInfObserverFetch = <
     const [isError, setIsError] = useState<boolean>(false);
     const [data, setData] = useState<BasePaginationResponse<MessageHistoryType[]> | null>(null);
     const [error, setError] = useState<Error | null>(null);
+
     const [hasNext, setHasNext] = useState<boolean>(true);
     const [lastMessageId, setLastMessageId] = useState<number | undefined>(undefined);
     const [initialLoad, setIsInitialLoad] = useState<boolean>(true);
@@ -35,13 +36,16 @@ export const useInfObserverFetch = <
     const [prevScrollTop, setPrevScrollTop] = useState<number>(0);
 
     const fetchPaginatedData = useCallback(async () => {
-        if (isPending || !hasNext || !scrollContainerRef.current) return;
+        if (isPending || !hasNext) return;
+
+        const scrollContainerElement = scrollContainerRef.current;
+        if (!scrollContainerElement) return;
 
         try {
             setIsPending(true);
 
-            const currentScrollHeight = scrollContainerRef.current.scrollHeight;
-            const currentScrollTop = scrollContainerRef.current.scrollTop;
+            const currentScrollHeight = scrollContainerElement.scrollHeight;
+            const currentScrollTop = scrollContainerElement.scrollTop;
             setPrevScrollHeight(currentScrollHeight);
             setPrevScrollTop(currentScrollTop);
 
@@ -80,9 +84,7 @@ export const useInfObserverFetch = <
     const observerCallback = useCallback(
         (entries: IntersectionObserverEntry[]) => {
             entries.forEach((entry) => {
-                if (entry.isIntersecting) {
-                    fetchPaginatedData();
-                }
+                if (entry.isIntersecting) fetchPaginatedData();
             });
         },
         [fetchPaginatedData],
@@ -101,6 +103,7 @@ export const useInfObserverFetch = <
             setPrevScrollHeight(0);
             setPrevScrollTop(0);
         }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [data]);
 
     // [2] IntersectionObserver 설정
@@ -112,12 +115,14 @@ export const useInfObserverFetch = <
             observerCallback,
             observerOptions,
         );
+
         intersectionObserverRef.current.observe(target);
 
         return () => {
             intersectionObserverRef.current?.unobserve(target);
         };
-    }, [observerCallback, observerOptions]);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [observerCallback, observerOptions, targetRef.current, scrollContainerRef.current]);
 
     return {
         isPending,

--- a/src/features/chat/hooks/usePreviousMessageHistory.ts
+++ b/src/features/chat/hooks/usePreviousMessageHistory.ts
@@ -11,7 +11,7 @@ export type MessageHistoryType = {
     createdAt: string;
 };
 
-const PAGE_SIZE = 30;
+const PAGE_SIZE = 20;
 
 export const getPreviousMessageHistory = async ({
     room_id,

--- a/src/pages/chat/ChatRoomPage.tsx
+++ b/src/pages/chat/ChatRoomPage.tsx
@@ -5,7 +5,6 @@ import { Vote } from "lucide-react";
 
 import { Screen } from "@/apps/Screen";
 
-import { ChatHistoryFallback } from "@/entities/chat/ui/ChatHistory/ChatHistoryFallback";
 import { ChatHistoryGroup } from "@/entities/chat/ui/ChatHistory/ChatHistoryGroup";
 import { ChatHistoryItem } from "@/entities/chat/ui/ChatHistory/ChatHistoryItem";
 import { ChatHistoryTime } from "@/entities/chat/ui/ChatHistory/ChatHistoryTime";
@@ -20,6 +19,7 @@ import { useInfObserverFetch } from "@/features/chat/hooks/useInfObserverFetch";
 import { usePutExitChatRoom } from "@/features/chat/service/exitChatRoom";
 import { useMatchDetail } from "@/features/match/service/readMatchDetail";
 import { ChatGradientLayer } from "@/shared/components/GradientLayers/ChatGradientLayer";
+import { Spinner } from "@/shared/components/Spinner/Spinner";
 import { parseJwt } from "@/shared/lib/decodeJWT";
 import { ActivityComponentType } from "@stackflow/react";
 
@@ -91,9 +91,16 @@ const ChatRoomPage: ActivityComponentType<ChatRoomPageParams> = ({ params }) => 
 
                     <ChatHistoryGroup ref={scrollContainerRef}>
                         <ChatHistoryTime timeStamp={"2022-01-01T00:00:00+09:00"} />
-                        {data && data.data.length > 0 && hasNext && (
-                            <ChatHistoryFallback ref={targetRef} />
+                        {hasNext && (
+                            <Spinner
+                                ref={targetRef}
+                                width={20}
+                                height={20}
+                                borderWidth={2}
+                                styles={{ margin: "0px auto" }}
+                            />
                         )}
+
                         {data?.data.flatMap((historyItems) => (
                             <ChatHistoryItem
                                 key={historyItems.id}

--- a/src/shared/components/Spinner/Spinner.tsx
+++ b/src/shared/components/Spinner/Spinner.tsx
@@ -1,0 +1,31 @@
+import { forwardRef } from "react";
+
+export interface SpinnerProps {
+    width: number;
+    height: number;
+    borderWidth: number;
+    styles?: React.CSSProperties;
+}
+
+export const Spinner = forwardRef<HTMLSpanElement, SpinnerProps>(
+    ({ width, height, borderWidth, styles }, ref) => {
+        return (
+            <span
+                ref={ref}
+                className={`
+                inline-block 
+                border-white 
+                border-b-transparent 
+                rounded-full 
+                animate-spin
+            `}
+                style={{
+                    width: `${width}px`,
+                    height: `${height}px`,
+                    borderWidth: `${borderWidth}px`,
+                    ...styles,
+                }}
+            />
+        );
+    },
+);


### PR DESCRIPTION
## 🖇️ 연결 된 이슈

- resolve #160 

## 🏞️ 첨부 파일

<img width="200" alt="image" src="https://github.com/user-attachments/assets/218a0e24-4c8f-4b57-ae52-8cdfc9c7701b" />

## 📋 변경 사항

- 채팅 히스토리 무한 스크롤이 제대로 동작하지 않는 현상 해결
  - `ref.current` 프로퍼티와 `isPending`, `hasNext` 상태 확인 코드 분리
  - `useEffect` 의존성 배열에서 누락된 값에 대한 `eslint-disable` 주석 추가